### PR TITLE
Add passwordCommand option to server modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository provides a Nix framework for configuring and deploying MCP serve
 - **Modular Configuration**: Define and combine multiple MCP server configurations
 - **Reproducible Builds**: Leverage Nix for reproducible and declarative server setups
 - **Pre-configured Modules**: Ready-to-use configurations for popular MCP server types
-- **Security-focused**: Better handling credentials and sensitive information, with pinned server versions
+- **Security-focused**: Better handling credentials and sensitive information through `envFile` and `passwordCommand`, with pinned server versions
 
 ## Available Modules
 
@@ -189,16 +189,18 @@ Each module provides specific configuration options, but there are some common o
 Each enabled module (using `programs.<module>.enable = true;`) provides the following options:
 
 - `package`: The package to use for this module
-- `wrapPackageWithEnvFile`: Whether to wrap the package with an environment file (default: `true` when flavor is not "vscode")
 - `type`: Server connection type (`sse` or `stdio`, default: `null`)
 - `args`: Array of arguments passed to the command (default: `[]`)
 - `env`: Environment variables for the server (default: `{}`)
 - `url`: URL of the server for "sse" connections (default: `null`)
 - `envFile`: Path to an .env file from which to load additional environment variables (default: `null`)
+- `passwordCommand`: Command to execute to retrieve secrets in the format "KEY=VALUE" which will be exported as environment variables, useful for integrating with password managers (default: `null`)
 
 ### Security Note
 
-For security reasons, do not hardcode authentication credentials in the `env` attribute. All files in `/nix/store` can be read by anyone with access to the store. Always use `envFile` instead.
+For security reasons, do not hardcode authentication credentials in the `env` attribute. All files in `/nix/store` can be read by anyone with access to the store. Always use `envFile` or `passwordCommand` instead.
+
+The system automatically wraps the package when either `envFile` or `passwordCommand` is set, which allows secure retrieval of credentials without exposing them in the Nix store.
 
 ### Adding Custom Servers
 

--- a/modules/assertions.nix
+++ b/modules/assertions.nix
@@ -1,0 +1,46 @@
+# This module provides the assertion and warning system infrastructure similar to NixOS.
+# It allows defining validation checks across the configuration to ensure that
+# certain conditions are met before the configuration is considered valid.
+#
+# The implementation is based on NixOS's assertions module:
+# https://github.com/NixOS/nixpkgs/blob/nixos-24.11/nixos/modules/misc/assertions.nix
+#
+# Currently, this only defines the options schema, but doesn't implement the actual
+# assertion checking functionality. This is needed as a placeholder to support
+# mkRemovedOptionModule and other validation functions that depend on these options.
+#
+# TODO: Implement the full assertion checking logic similar to NixOS's activation system.
+# Reference: <nixpkgs/nixos/modules/system/activation/top-level.nix>
+
+{ lib, ... }:
+{
+  options = {
+    assertions = lib.mkOption {
+      type = lib.types.listOf lib.types.unspecified;
+      internal = true;
+      default = [ ];
+      example = [
+        {
+          assertion = false;
+          message = "you can't enable this for that reason";
+        }
+      ];
+      description = ''
+        This option allows modules to express conditions that must
+        hold for the evaluation of the system configuration to
+        succeed, along with associated error messages for the user.
+      '';
+    };
+
+    warnings = lib.mkOption {
+      internal = true;
+      default = [ ];
+      type = lib.types.listOf lib.types.str;
+      example = [ "The `foo' service is deprecated and will go away soon!" ];
+      description = ''
+        This option allows modules to show warnings to users during
+        the evaluation of the system configuration.
+      '';
+    };
+  };
+}


### PR DESCRIPTION
This PR adds a new `passwordCommand` option to the server module configuration system, enhancing the security capabilities of MCP servers.

### Changes

- Added a new `passwordCommand` option that allows users to specify a command to execute to retrieve secrets, which is useful for integrating with password managers or other security tools
- Removed the deprecated `wrapPackageWithEnvFile` option as it is no longer needed
- Modified the wrapper script to process credentials from both sources into environment variables
- Added assertions module placeholder to support option removal warnings

### Example

```nix
programs.github = {
  enable = true;
  passwordCommand = "pass gh-token";
};
```