### PR TITLE
fix evaluation error of wrapped package

### DIFF
--- a/examples/claude-desktop.nix
+++ b/examples/claude-desktop.nix
@@ -7,5 +7,9 @@ in
 mcp-servers.lib.mkConfig pkgs {
   programs = {
     filesystem.enable = true;
+    github = {
+      enable = true;
+      envFile = ./dummy-gh-token;
+    };
   };
 }

--- a/examples/default.nix
+++ b/examples/default.nix
@@ -3,10 +3,16 @@ let
   inherit (pkgs) lib;
 in
 builtins.listToAttrs (
-  map (
-    example:
-    lib.nameValuePair ("example-${lib.removeSuffix ".nix" example}") (
-      import (./. + "/${example}") { inherit pkgs; }
+  map
+    (
+      example:
+      lib.nameValuePair ("example-${lib.removeSuffix ".nix" example}") (
+        import (./. + "/${example}") { inherit pkgs; }
+      )
     )
-  ) (builtins.filter (file: file != "default.nix") (builtins.attrNames (builtins.readDir ./.)))
+    (
+      builtins.filter (file: (lib.hasSuffix ".nix" file) && (file != "default.nix")) (
+        builtins.attrNames (builtins.readDir ./.)
+      )
+    )
 )

--- a/examples/dummy-gh-token
+++ b/examples/dummy-gh-token
@@ -1,0 +1,1 @@
+GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_dummy

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -104,7 +104,7 @@ let
           wrapped-package = pkgs.writeScriptBin packageName ''
             #!${pkgs.runtimeShell}
             ${lib.optionalString exportEnvFile (
-              mkExportCommand ((lib.getExe' pkgs.coreutils "cat") (lib.escapeShellArg cfg.envFile))
+              mkExportCommand ("${lib.getExe' pkgs.coreutils "cat"} ${lib.escapeShellArg cfg.envFile}")
             )}
             ${lib.optionalString exportPasswordCommand (mkExportCommand cfg.passwordCommand)}
             ${lib.getExe cfg.package} "$@"


### PR DESCRIPTION
```
error: attempt to call something which is not a function but a string with context: "/nix/store/4idwmksk4s5bdmzl1sz1z17bj0yfqgkj-coreutils-9.6/bin/cat"
  at /nix/store/7p4f57kw6025vydzlj88gv9dwjvjisk4-source/lib/default.nix:107:33:
  106|             ${lib.optionalString exportEnvFile (
  107|               mkExportCommand ((lib.getExe' pkgs.coreutils "cat") (lib.escapeShellArg cfg.envFile))
     |                                 ^
  108|             )}
```

## Changes

- Add more example
- Fix evaluation error
