### PR TITLE
github-mcp-server: 0.1.1 -> 0.2.0

### DIFF
--- a/pkgs/official/github/default.nix
+++ b/pkgs/official/github/default.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "github-mcp-server";
-  version = "0.1.1";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "github-mcp-server";
     tag = "v${version}";
-    hash = "sha256-cIS6awIzGadeDdIfSmHKlL9NhouZwQAND7Au8zz0HJA=";
+    hash = "sha256-FMkulZoZtvu2aZC1qAszoIbKpWRoyY2LyQEUw6irawM=";
   };
 
-  vendorHash = "sha256-eBKTnuJk705oE//ejdwu/hi1hq8N88C6e4dEkKuM+5g=";
+  vendorHash = "sha256-LjwvIn/7PLZkJrrhNdEv9J6sj5q3Ljv70z3hDeqC5Sw=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Diff: https://github.com/github/github-mcp-server/compare/refs/tags/v0.1.1...refs/tags/v0.2.0

Changelog: https://github.com/github/github-mcp-server/releases/tag/v0.2.0