### PR TITLE
feat: add vscode-workspace flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Check the `examples` directory for complete configuration examples:
 - [`claude-desktop.nix`](./examples/claude-desktop.nix): Basic configuration for Claude Desktop
 - [`vscode.nix`](./examples/vscode.nix): VS Code integration setup
 - [`librechat.nix`](./examples/librechat.nix): Configuration for LibreChat integration
+- [`vscode-workspace`](./examples/vscode-workspace/flake.nix): VS Code workspace configuration example
 
 ### Real World Examples
 

--- a/examples/vscode-workspace/flake.nix
+++ b/examples/vscode-workspace/flake.nix
@@ -1,0 +1,80 @@
+{
+  description = "Example of VSCode workspace";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    mcp-servers-nix = {
+      url = "github:natsukium/mcp-servers-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      mcp-servers-nix,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+      forAllSystems = lib.genAttrs [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [ vscode ];
+            shellHook =
+              let
+                config = mcp-servers-nix.lib.mkConfig pkgs {
+                  fileName = "mcp.json";
+                  flavor = "vscode-workspace";
+                  programs = {
+                    filesystem = {
+                      enable = true;
+                      args = [
+                        # NOTE: Using builtins.getEnv requires running `nix develop` with --impure flag
+                        "${toString (builtins.getEnv "PWD")}"
+                      ];
+                    };
+                    github = {
+                      enable = true;
+                      env = {
+                        GITHUB_PERSONAL_ACCESS_TOKEN = ''''${input:github_token}'';
+                      };
+                    };
+                  };
+                  settings.inputs = [
+                    {
+                      type = "promptString";
+                      id = "github_token";
+                      description = "GitHub Personal Access Token";
+                      password = true;
+                    }
+                  ];
+                };
+              in
+              ''
+                if [ -L ".vscode/mcp.json" ]; then
+                  unlink .vscode/mcp.json
+                fi
+                mkdir -p .vscode
+                ln -sf ${config} .vscode/mcp.json
+              '';
+          };
+        }
+      );
+    };
+}

--- a/modules/config.nix
+++ b/modules/config.nix
@@ -20,10 +20,14 @@
       type = lib.types.enum [
         "claude"
         "vscode"
+        "vscode-workspace"
       ];
       default = "claude";
       description = ''
         Configuration file type.
+        - "claude": Standard Claude Desktop configuration format using "mcpServers" key
+        - "vscode": VSCode global configuration format using "mcp.servers" keys
+        - "vscode-workspace": VSCode workspace configuration format with top-level "servers" key,
       '';
     };
     fileName = lib.mkOption {
@@ -56,6 +60,8 @@
             "mcp"
             "servers"
           ]
+        else if (config.flavor == "vscode-workspace") then
+          [ "servers" ]
         else
           [ "mcpServers" ];
     in


### PR DESCRIPTION
This PR adds VSCode Workspace configuration support.

## Changes

- Added flavor = "vscode-workspace" option
- Added `examples/vscode-workspace/flake.nix` as a configuration example for VSCode Workspace

## Example

See https://github.com/natsukium/mcp-servers-nix/blob/37c783d3d1641c036f3fa5187b6aae071e6ac79f/examples/vscode-workspace/flake.nix

closes #16