### PR TITLE
add a flavor for the zed editor

### DIFF
--- a/modules/config.nix
+++ b/modules/config.nix
@@ -21,6 +21,7 @@
         "claude"
         "vscode"
         "vscode-workspace"
+        "zed"
       ];
       default = "claude";
       description = ''
@@ -28,6 +29,7 @@
         - "claude": Standard Claude Desktop configuration format using "mcpServers" key
         - "vscode": VSCode global configuration format using "mcp.servers" keys
         - "vscode-workspace": VSCode workspace configuration format with top-level "servers" key,
+        - "zed": Zed configuration format with top-level "context_servers" key,
       '';
     };
     fileName = lib.mkOption {
@@ -62,6 +64,8 @@
           ]
         else if (config.flavor == "vscode-workspace") then
           [ "servers" ]
+        else if (config.flavor == "zed") then
+          [ "context_servers" ]
         else
           [ "mcpServers" ];
     in


### PR DESCRIPTION
zed expects the top-level keyword "context_servers" which isnt available from any of the flavors currently.
the relative documentation is available at [](https://zed.dev/docs/assistant/context-servers).
thank you for this effort!