### PR TITLE
ci: split cache keys by architecture to improve restore time

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -24,10 +24,10 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
       - uses: nix-community/cache-nix-action@c448f065ba14308da81de769632ca67a3ce67cf5 # v6.1.2
         with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
+          primary-key: nix-${{ matrix.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ matrix.os }}-
           purge: true
-          purge-prefixes: nix-${{ runner.os }}-
+          purge-prefixes: nix-${{ matrix.os }}-
           purge-created: 0
       - name: Run nix flake check
         run: nix flake check --option keep-going true


### PR DESCRIPTION
Addresses the significant cache restoration delay in macos-13 environments.
macos-13 currently takes approximately twice as long as macos-latest and over five times longer than linux to restore cache.

By splitting cache keys by machine architecture, each environment only restores necessary data.
This change improves CI performance and reduces build times, especially in macos-13 environments.