### PR TITLE
github-mcp-server: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/official/github/default.nix
+++ b/pkgs/official/github/default.nix
@@ -6,13 +6,13 @@
 
 buildGoModule rec {
   pname = "github-mcp-server";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "github-mcp-server";
     tag = "v${version}";
-    hash = "sha256-FMkulZoZtvu2aZC1qAszoIbKpWRoyY2LyQEUw6irawM=";
+    hash = "sha256-vbL96EXzgbjqVJaKizYIe8Fne60CVx7v/5ya9Xx3JvA=";
   };
 
   vendorHash = "sha256-LjwvIn/7PLZkJrrhNdEv9J6sj5q3Ljv70z3hDeqC5Sw=";


### PR DESCRIPTION
Diff: https://github.com/github/github-mcp-server/compare/refs/tags/v0.2.0...refs/tags/v0.2.1

Changelog: https://github.com/github/github-mcp-server/releases/tag/v0.2.1