### PR TITLE
mcp-grafana: 0.2.6 -> 0.3.0

### DIFF
--- a/pkgs/official/grafana/default.nix
+++ b/pkgs/official/grafana/default.nix
@@ -6,13 +6,13 @@
 
 buildGoModule rec {
   pname = "mcp-grafana";
-  version = "0.2.6";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "mcp-grafana";
     tag = "v${version}";
-    hash = "sha256-6GtYJYpf4tIybYDgoywFCaMXggmtPLbWk3WLFA0OUd8=";
+    hash = "sha256-qgT92ePK/o0b+nxsSs2yHcmPeE7r0cY+jStYTU+duIQ=";
   };
 
   vendorHash = "sha256-GUSMJizNt0C8tx3koVFmMnJPhThYM9Fy1iGI86ZkYe0=";


### PR DESCRIPTION
Diff: https://github.com/grafana/mcp-grafana/compare/refs/tags/v0.2.6...refs/tags/v0.3.0

Changelog: https://github.com/grafana/mcp-grafana/releases/tag/v0.3.0