### PR TITLE
notion-mcp-server: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/official/notion/default.nix
+++ b/pkgs/official/notion/default.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage {
   pname = "notion-mcp-server";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "makenotion";
     repo = "notion-mcp-server";
-    rev = "5771f71ddbe932e2eb4f37d7fd8700a55d51b6d0";
-    hash = "sha256-nZb7iJ3EjahTcLeBckEJWaqnxlQtsuECZdRMm77juTQ=";
+    rev = "e55be1e9e99fbe3196d35944db144e905d056713";
+    hash = "sha256-AqRrPBVbZ9QduU1M4Vogja4jEshMFvt69zh+x/1PAuo=";
   };
 
-  npmDepsHash = "sha256-WiMgekr2mBJHAIS1AJ8f+rKzpboFcCylXRcUuUl54VQ=";
+  npmDepsHash = "sha256-cJT0Kg04lLFBqp/SdYuECOTmDPGRwCuHjvRImAhC6GU=";
 
   meta = {
     description = "Official Notion MCP Server";


### PR DESCRIPTION
Diff: https://github.com/makenotion/notion-mcp-server/compare/5771f71ddbe932e2eb4f37d7fd8700a55d51b6d0...e55be1e9e99fbe3196d35944db144e905d056713