### PR TITLE
github-mcp-server: 0.2.1 -> 0.4.0

### DIFF
--- a/pkgs/official/github/default.nix
+++ b/pkgs/official/github/default.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "github-mcp-server";
-  version = "0.2.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "github-mcp-server";
     tag = "v${version}";
-    hash = "sha256-vbL96EXzgbjqVJaKizYIe8Fne60CVx7v/5ya9Xx3JvA=";
+    hash = "sha256-7bxphEQOewy7RZIfKp6aEIPvhgvq4AsU8FozsDsGVgM=";
   };
 
-  vendorHash = "sha256-LjwvIn/7PLZkJrrhNdEv9J6sj5q3Ljv70z3hDeqC5Sw=";
+  vendorHash = "sha256-yUg+4Z8e9j4wpDD+5XG7pZFnxibGiI5Gks1CEQT2E3g=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Diff: https://github.com/github/github-mcp-server/compare/refs/tags/v0.2.1...refs/tags/v0.4.0

Changelog: https://github.com/github/github-mcp-server/releases/tag/v0.4.0