### PR TITLE
context7-mcp: init at 1.0.13

### DIFF
--- a/modules/context7.nix
+++ b/modules/context7.nix
@@ -1,0 +1,4 @@
+{ mkServerModule, ... }:
+{
+  imports = [ (mkServerModule { name = "context7"; }) ];
+}

--- a/modules/context7.nix
+++ b/modules/context7.nix
@@ -1,4 +1,7 @@
 { mkServerModule, ... }:
 {
-  imports = [ (mkServerModule { name = "context7"; }) ];
+  imports = [ (mkServerModule {
+    name = "context7";
+    packageName = "mcp-context7";
+  }) ];
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55,6 +55,7 @@
   mcp-server-time = pkgs.callPackage ./reference/time.nix { };
 
   # official servers
+  mcp-context7-server = pkgs.callPackage ./official/context7 { };
   mcp-grafana = pkgs.callPackage ./official/grafana { };
   notion-mcp-server = pkgs.callPackage ./official/notion { };
   playwright-mcp = pkgs.callPackage ./official/playwright { };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55,7 +55,7 @@
   mcp-server-time = pkgs.callPackage ./reference/time.nix { };
 
   # official servers
-  mcp-context7-server = pkgs.callPackage ./official/context7 { };
+  mcp-context7 = pkgs.callPackage ./official/context7 { };
   mcp-grafana = pkgs.callPackage ./official/grafana { };
   notion-mcp-server = pkgs.callPackage ./official/notion { };
   playwright-mcp = pkgs.callPackage ./official/playwright { };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55,7 +55,7 @@
   mcp-server-time = pkgs.callPackage ./reference/time.nix { };
 
   # official servers
-  mcp-context7 = pkgs.callPackage ./official/context7 { };
+  context7-mcp = pkgs.callPackage ./official/context7 { };
   mcp-grafana = pkgs.callPackage ./official/grafana { };
   notion-mcp-server = pkgs.callPackage ./official/notion { };
   playwright-mcp = pkgs.callPackage ./official/playwright { };

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -48,7 +48,7 @@ let
 
   # Step 2: Main build derivation
 in stdenv.mkDerivation rec {
-  pname = "context7-mcp-server";
+  pname = "mcp-context7";
   inherit version src;
 
   nativeBuildInputs = [ bun makeWrapper ];

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -12,6 +12,7 @@ let
   version = "1.0.12";
 
   src = fetchFromGitHub {
+    # TODO: wait until merge https://github.com/upstash/context7/pull/248
     owner = "vaporif";
     repo = "context7";
     rev = "fcd166d95f3619378df8c35c5619ac6e420535a8";

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -5,6 +5,9 @@
   bun,
   makeWrapper,
 }:
+
+# TODO: would be great to remove this once nixpkgs
+# has native build bun packages derivation
 let
   version = "1.0.12";
 
@@ -12,7 +15,7 @@ let
     owner = "vaporif";
     repo = "context7";
     rev = "fcd166d95f3619378df8c35c5619ac6e420535a8";
-    hash = "sha256-rDDWjhFS6X0WN8UPbP93bGnPo2YPOjndbFiKMI+zHJ0="; # Replace with actual hash
+    hash = "sha256-rDDWjhFS6X0WN8UPbP93bGnPo2YPOjndbFiKMI+zHJ0=";
   };
 
   # Step 1: Fixed-output derivation for dependencies
@@ -45,7 +48,7 @@ let
 
   # Step 2: Main build derivation
 in stdenv.mkDerivation rec {
-  pname = "context7-mcp";
+  pname = "context7-mcp-server";
   inherit version src;
 
   nativeBuildInputs = [ bun makeWrapper ];
@@ -92,7 +95,7 @@ in stdenv.mkDerivation rec {
     description = "Context7 MCP Server - Up-to-date code documentation for LLMs and AI code editors";
     homepage = "https://context7.com";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers =  [ "vaporif" ];
     mainProgram = "context7-mcp";
   };
 }

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -15,7 +15,7 @@ let
   src = fetchFromGitHub {
     owner = "upstash";
     repo = "context7";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-vtwr7q80spmMuGbdc98DX822o8uF9wTbHeA3mEGXai8=";
   };
 

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  bun,
+  makeWrapper,
+}:
+let
+  version = "1.0.12";
+
+  src = fetchFromGitHub {
+    owner = "vaporif";
+    repo = "context7";
+    rev = "fcd166d95f3619378df8c35c5619ac6e420535a8";
+    hash = "sha256-rDDWjhFS6X0WN8UPbP93bGnPo2YPOjndbFiKMI+zHJ0="; # Replace with actual hash
+  };
+
+  # Step 1: Fixed-output derivation for dependencies
+  deps = stdenv.mkDerivation {
+    pname = "context7-mcp-deps";
+    inherit version src;
+
+    nativeBuildInputs = [ bun ];
+
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      export HOME=$TMPDIR
+
+      # Install dependencies
+      bun install --frozen-lockfile --no-cache
+
+      # Copy to output
+      mkdir -p $out
+      cp -r node_modules $out/
+      cp bun.lock package.json $out/
+    '';
+
+    # This hash represents the dependencies
+    outputHash = "sha256-y9R0MXNH5DO2sxv+eibwrueNZC8jCAVCrMfjJ6FI50E=";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+  # Step 2: Main build derivation
+in stdenv.mkDerivation rec {
+  pname = "context7-mcp";
+  inherit version src;
+
+  nativeBuildInputs = [ bun makeWrapper ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$TMPDIR
+
+    cp -r ${deps}/node_modules .
+    cp ${deps}/bun.lock .
+
+    bun run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/context7-mcp
+
+    cp -r dist $out/lib/context7-mcp/
+
+    cp -r node_modules $out/lib/context7-mcp/
+    cp package.json $out/lib/context7-mcp/
+
+    sed -i '1s|^|#!/usr/bin/env bun\n|' $out/lib/context7-mcp/dist/index.js
+    chmod +x $out/lib/context7-mcp/dist/index.js
+
+    mkdir -p $out/bin
+    makeWrapper $out/lib/context7-mcp/dist/index.js $out/bin/context7-mcp \
+      --prefix PATH : ${lib.makeBinPath [ bun ]} \
+      --set NODE_ENV production
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit deps;
+  };
+
+  meta = {
+    description = "Context7 MCP Server - Up-to-date code documentation for LLMs and AI code editors";
+    homepage = "https://context7.com";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "context7-mcp";
+  };
+}

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -49,7 +49,7 @@ let
 
   # Step 2: Main build derivation
 in stdenv.mkDerivation {
-  pname = "mcp-context7";
+  pname = "context7-mcp";
   inherit version src;
 
   nativeBuildInputs = [ bun makeWrapper ];

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -91,7 +91,7 @@ in stdenv.mkDerivation {
   };
 
   meta = {
-    description = "Context7 MCP Server - Up-to-date code documentation for LLMs and AI code editors";
+    description = "Up-to-date code documentation for LLMs and AI code editors";
     homepage = "https://context7.com";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ natsukium vaporif ];

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -13,11 +13,10 @@ let
   version = "1.0.12";
 
   src = fetchFromGitHub {
-    # TODO: wait until merge https://github.com/upstash/context7/pull/248
-    owner = "vaporif";
+    owner = "upstash";
     repo = "context7";
-    rev = "fcd166d95f3619378df8c35c5619ac6e420535a8";
-    hash = "sha256-rDDWjhFS6X0WN8UPbP93bGnPo2YPOjndbFiKMI+zHJ0=";
+    rev = "8a8cfa1c82d20e13e17a2c8e854e48bb31d69e2d";
+    hash = "sha256-T15u7aI/ro5vCvnOD4RMT5YK7uAIkAYvwCkJYLqV8Eo=";
   };
 
   # Step 1: Fixed-output derivation for dependencies

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -10,13 +10,13 @@
 # TODO: would be great to remove this once nixpkgs
 # has native build bun packages derivation
 let
-  version = "1.0.12";
+  version = "1.0.13";
 
   src = fetchFromGitHub {
     owner = "upstash";
     repo = "context7";
-    rev = "8a8cfa1c82d20e13e17a2c8e854e48bb31d69e2d";
-    hash = "sha256-T15u7aI/ro5vCvnOD4RMT5YK7uAIkAYvwCkJYLqV8Eo=";
+    rev = "v${version}";
+    hash = "sha256-vtwr7q80spmMuGbdc98DX822o8uF9wTbHeA3mEGXai8=";
   };
 
   # Step 1: Fixed-output derivation for dependencies
@@ -42,7 +42,7 @@ let
     '';
 
     # This hash represents the dependencies
-    outputHash = "sha256-y9R0MXNH5DO2sxv+eibwrueNZC8jCAVCrMfjJ6FI50E=";
+    outputHash = "sha256-vNgJRV23T9/cfTHI5FRiW5K64VIxB5nehADZ1AeuAj0=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   bun,
   makeWrapper,
+  nodejs-slim,
 }:
 
 # TODO: would be great to remove this once nixpkgs
@@ -77,13 +78,11 @@ in stdenv.mkDerivation rec {
     cp -r node_modules $out/lib/context7-mcp/
     cp package.json $out/lib/context7-mcp/
 
-    sed -i '1s|^|#!/usr/bin/env bun\n|' $out/lib/context7-mcp/dist/index.js
     chmod +x $out/lib/context7-mcp/dist/index.js
 
     mkdir -p $out/bin
     makeWrapper $out/lib/context7-mcp/dist/index.js $out/bin/context7-mcp \
-      --prefix PATH : ${lib.makeBinPath [ bun ]} \
-      --set NODE_ENV production
+      --prefix PATH : ${lib.makeBinPath [ nodejs-slim ]} \
 
     runHook postInstall
   '';

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -94,7 +94,7 @@ in stdenv.mkDerivation rec {
     description = "Context7 MCP Server - Up-to-date code documentation for LLMs and AI code editors";
     homepage = "https://context7.com";
     license = lib.licenses.mit;
-    maintainers =  [ "vaporif" ];
+    maintainers = with lib.maintainers; [ natsukium vaporif ];
     mainProgram = "context7-mcp";
   };
 }

--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -48,7 +48,7 @@ let
   };
 
   # Step 2: Main build derivation
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation {
   pname = "mcp-context7";
   inherit version src;
 


### PR DESCRIPTION
First thing thanks for heavylifting on mcp nix side. Very easy integrate to, including with nix-sops. I want to add imho default server for any dev.
https://context7.com/
Nobrainer mcp for up to date documentation for programming languages/libs.
Since there's no [buildBunPackages](https://github.com/NixOS/nixpkgs/issues/255890) I've slapped together manual build (this could be omitted if they just had package.json or yarn or pnpm). Had to do 2-step one to check hash of both node packages cash and downloaded github.
Yeah, and their official repo lockfiles are outdated, so until they merge in my [PR](https://github.com/upstash/context7/pull/248) I'm using my fork. Totally ok if you'd want to wait for it.