### PR TITLE
reference-server: 2025.7.1 -> 2025.8.4

### DIFF
--- a/pkgs/reference/generic-ts.nix
+++ b/pkgs/reference/generic-ts.nix
@@ -13,7 +13,7 @@ buildNpmPackage {
   pname = "mcp-server-${service}";
   inherit (import ./source.nix { inherit fetchFromGitHub; }) version src;
 
-  npmDepsHash = "sha256-5QT6d4SpdPHJC55s9k3/qDmzo9C7tr/9RDYHR6sqMpw=";
+  npmDepsHash = "sha256-qIsj4XCMqFxqsfjZzs/eDM57U+BI3yJ6h6sdMHXgLvU=";
 
   npmWorkspace = "src/${workspace}";
 

--- a/pkgs/reference/source.nix
+++ b/pkgs/reference/source.nix
@@ -1,10 +1,10 @@
 { fetchFromGitHub }:
 rec {
-  version = "2025.7.1";
+  version = "2025.8.4";
   src = fetchFromGitHub {
     owner = "modelcontextprotocol";
     repo = "servers";
     tag = version;
-    hash = "sha256-Ujzr3F34550JA/hxKmFHXugX41duxcUVXU4nYmlMtDs=";
+    hash = "sha256-wD0OToLGy9Jyid4PaC8+dqAkIhDQY0c9CT7gcTLMz2Y=";
   };
 }


### PR DESCRIPTION
https://github.com/modelcontextprotocol/servers/compare/2025.7.1...2025.8.4