### PR TITLE
ci: switch to nixpkgs nix-update to use released version

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Update package
         id: update-package
         run: |
-          OUTPUT=$(nix run github:Mic92/nix-update \
+          OUTPUT=$(nix run nixpkgs#nix-update \
             -- --flake ${{ matrix.package }} --print-commit-message)
 
           # Extract title (first line containing package name)


### PR DESCRIPTION
The necessary patches have been released, so we can now use the nixpkgs version instead of the upstream. This also resolves the Go version compatibility error.