### PR TITLE
serena: add configuration options for context and web dashboard

### DIFF
--- a/modules/serena.nix
+++ b/modules/serena.nix
@@ -2,10 +2,24 @@
   config,
   lib,
   mkServerModule,
+  servers,
   ...
 }:
 let
   cfg = config.programs.serena;
+
+  finalPackage =
+    if cfg.extraPackages == [ ] then
+      servers.serena
+    else
+      servers.serena.overrideAttrs (oldAttrs: {
+        makeWrapperArgs = (oldAttrs.makeWrapperArgs or [ ]) ++ [
+          "--prefix"
+          "PATH"
+          ":"
+          (lib.makeBinPath cfg.extraPackages)
+        ];
+      });
 in
 {
   imports = [
@@ -15,9 +29,61 @@ in
     })
   ];
 
-  config.settings.servers = lib.mkIf cfg.enable {
-    serena = {
-      args = [ "start-mcp-server" ];
+  options.programs.serena = {
+    context = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "agent"
+          "chatgpt"
+          "codex"
+          "desktop-app"
+          "ide-assistant"
+          "oaicompat-agent"
+        ]
+      );
+      default = null;
+      description = ''
+        Built-in context name. See https://github.com/oraios/serena/tree/main/src/serena/resources/config/contexts for available contexts.
+        If null, the default context will be used.
+      '';
+    };
+
+    enableWebDashboard = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = ''
+        Enable or disable the Serena web dashboard.
+        If null, the default setting will be used.
+      '';
+    };
+
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.nixd pkgs.rust-analyzer ]";
+      description = ''
+        Extra packages available in the serena wrapper's PATH.
+        This is useful for including language servers and other tools
+        that serena needs to access.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.serena.package = lib.mkDefault finalPackage;
+
+    settings.servers.serena = {
+      args = [
+        "start-mcp-server"
+      ]
+      ++ lib.optionals (cfg.context != null) [
+        "--context"
+        cfg.context
+      ]
+      ++ lib.optionals (cfg.enableWebDashboard != null) [
+        "--enable-web-dashboard"
+        (if cfg.enableWebDashboard then "true" else "false")
+      ];
     };
   };
 }


### PR DESCRIPTION
## Summary
- Add `context` option to specify built-in Serena contexts
- Add `enableWebDashboard` option to control web dashboard
- Add `extraPackages` option to include additional tools in PATH

## New Configuration Options

### 1. Context Selection
Choose from Serena's built-in contexts for different environments:

```nix
{
  programs.serena = {
    enable = true;
    # Use IDE assistant context for better IDE integration
    context = "ide-assistant";
  };
}
```

Available contexts:
- `agent` - For agent-based interactions
- `chatgpt` - ChatGPT-like interface
- `codex` - Code-focused assistant
- `desktop-app` - Desktop application integration
- `ide-assistant` - IDE integration (recommended for development)
- `oaicompat-agent` - OpenAI-compatible agent

### 2. Web Dashboard
Enable or disable Serena's web dashboard:

```nix
{
  programs.serena = {
    enable = true;
    enableWebDashboard = true;  # Enable the web dashboard
  };
}
```

### 3. Extra Packages
Add language servers and other tools to Serena's PATH:

```nix
{
  programs.serena = {
    enable = true;
    # Include language servers for better code analysis
    extraPackages = [
      pkgs.rust-analyzer
      pkgs.nixd
      pkgs.gopls
      pkgs.nodePackages.typescript-language-server
    ];
  };
}
```

### Complete Example
Here's a full configuration using all new options:

```nix
{
  programs.serena = {
    enable = true;
    context = "ide-assistant";
    enableWebDashboard = true;
    extraPackages = [
      pkgs.rust-analyzer
      pkgs.nixd
    ];
  };
}
```

## Test Plan
- [x] Module builds successfully
- [x] Options are properly passed to serena command
- [x] extraPackages are available in PATH when wrapped