### PR TITLE
ci: reduce update-packages workflow frequency to 6 hours

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -2,7 +2,7 @@ name: Update packages
 
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Changed from 3-hour to 6-hour intervals to reduce excessive automation frequency while maintaining regular updates.