### PR TITLE
reference-servers: 2025.8.4 -> 2025.9.25

### DIFF
--- a/pkgs/reference/generic-ts.nix
+++ b/pkgs/reference/generic-ts.nix
@@ -13,7 +13,7 @@ buildNpmPackage {
   pname = "mcp-server-${service}";
   inherit (import ./source.nix { inherit fetchFromGitHub; }) version src;
 
-  npmDepsHash = "sha256-qIsj4XCMqFxqsfjZzs/eDM57U+BI3yJ6h6sdMHXgLvU=";
+  npmDepsHash = "sha256-iRPILytyloL6qRMvy2fsDdqkewyqEfcuVspwUN5Lrqw=";
 
   npmWorkspace = "src/${workspace}";
 

--- a/pkgs/reference/source.nix
+++ b/pkgs/reference/source.nix
@@ -1,10 +1,10 @@
 { fetchFromGitHub }:
 rec {
-  version = "2025.8.4";
+  version = "2025.9.25";
   src = fetchFromGitHub {
     owner = "modelcontextprotocol";
     repo = "servers";
     tag = version;
-    hash = "sha256-wD0OToLGy9Jyid4PaC8+dqAkIhDQY0c9CT7gcTLMz2Y=";
+    hash = "sha256-ysTuSHFs7GABMuFXG+DcyonVXVs7m45j9sDPdHBS2wQ=";
   };
 }


### PR DESCRIPTION
Diff: https://github.com/modelcontextprotocol/servers/compare/2025.8.4...2025.9.25