### PR TITLE
ci: replace macos-13 with macos-15-intel runner

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13 ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel ]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
macos-13 runner used for Intel CPU support has been deprecated, so replacing it with macos-15-intel to maintain Intel architecture coverage in CI workflow.