### PR TITLE
fix(reference-servers): handle npm workspace symlinks in build output

### DIFF
--- a/pkgs/reference/generic-ts.nix
+++ b/pkgs/reference/generic-ts.nix
@@ -8,6 +8,8 @@
   buildNpmPackage,
   typescript,
   writeScriptBin,
+  makeBinaryWrapper,
+  nodejs,
 }:
 buildNpmPackage {
   pname = "mcp-server-${service}";
@@ -20,11 +22,23 @@ buildNpmPackage {
   env.PUPPETEER_SKIP_DOWNLOAD = true;
 
   nativeBuildInputs = [
+    makeBinaryWrapper
     typescript
     (writeScriptBin "shx" "")
   ];
 
-  dontCheckForBrokenSymlinks = true;
+  # Workaround for npmInstallHook limitation with npm workspaces:
+  # - Workspaces create symlinks in root node_modules (e.g., @modelcontextprotocol/server-* -> ../../src/*)
+  # - Non-hoisted dependencies are installed in each workspace's node_modules
+  # - npmInstallHook only copies files from `npm pack`, which excludes node_modules/
+  # - This breaks symlinks as src/ directories are not copied to output
+  # - Therefore, we must copy src/ manually and point the wrapper to src/${workspace}/dist/index.js
+  #   instead of a hypothetical root-level dist/index.js
+  postInstall = ''
+    cp -r src "$out/lib/node_modules/@modelcontextprotocol/servers/src"
+    makeWrapper "${nodejs}/bin/node" "$out/bin/mcp-server-${service}" \
+      --add-flags "$out/lib/node_modules/@modelcontextprotocol/servers/src/${workspace}/dist/index.js"
+  '';
 
   meta = {
     description = "Model Context Protocol Servers for ${service}";


### PR DESCRIPTION
## Summary

- Replace `dontCheckForBrokenSymlinks` with proper npm workspace handling
- Add `postInstall` hook to manually copy `src/` directory
- Use `makeWrapper` to point binaries to workspace-local dist files

## Background

npmInstallHook excludes `node_modules/` from the output (via `npm pack`), which breaks workspace symlinks created in the root `node_modules/`. This prevents reference MCP servers from finding their dependencies.

## Solution

Manually copy the `src/` directory to preserve the workspace structure and dependencies, then use `makeWrapper` to reference the correct entry point at `src/${workspace}/dist/index.js`.

## Test plan

- [ ] Build reference servers (e.g., `nix build .#mcp-server-filesystem`)
- [ ] Verify binaries execute without broken symlink errors
- [ ] Test that workspace dependencies are accessible at runtime