### PR TITLE
feat: add OpenCode flavor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Check the `examples` directory for complete configuration examples:
 - [`vscode.nix`](./examples/vscode.nix): VS Code integration setup
 - [`librechat.nix`](./examples/librechat.nix): Configuration for LibreChat integration
 - [`codex.nix`](./examples/codex.nix): Codex CLI integration with MCP servers
+- [`opencode.nix`](./examples/opencode.nix): OpenCode CLI integration with MCP servers
 - [`vscode-workspace`](./examples/vscode-workspace/flake.nix): VS Code workspace configuration example
 - [`flake-parts-module`](./examples/flake-parts-module/flake.nix): Flake-parts module integration with multi-flavor support
 
@@ -259,7 +260,7 @@ Each module provides specific configuration options, but there are some common o
 ### Global Options
 
 - `format`: Configuration file format (`json`, `yaml`, or `toml-inline`, default: `json`)
-- `flavor`: Configuration file type (`claude`, `vscode`, or `codex`, default: `claude`)
+- `flavor`: Configuration file type (`claude`, `vscode`, `codex`, or `opencode`, default: `claude`)
 - `fileName`: Configuration file name (default: `claude_desktop_config.json`)
 - `settings`: Custom settings that will be merged with the generated configuration
 

--- a/examples/opencode.nix
+++ b/examples/opencode.nix
@@ -1,0 +1,46 @@
+# OpenCode configuration example
+# Generates ~/.config/opencode/opencode.json format
+#
+# OpenCode MCP format differences from Claude:
+# - Root key: "mcp" (not "mcpServers")
+# - command: array including args (not separate command + args)
+# - environment: (not "env")
+# - type: "local" or "remote" (not "stdio"/"http"/"sse")
+# - enabled: boolean field
+#
+# Usage: nix-build examples/opencode.nix
+# Result will contain opencode.json
+{
+  pkgs ? import <nixpkgs> { },
+}:
+let
+  mcp-servers = import ../. { inherit pkgs; };
+in
+mcp-servers.lib.mkConfig pkgs {
+  flavor = "opencode";
+  fileName = "opencode.json";
+
+  programs = {
+    # Local MCP server example
+    filesystem = {
+      enable = true;
+      args = [ "/path/to/allowed/directory" ];
+    };
+
+    # Server with environment variables
+    fetch = {
+      enable = true;
+    };
+
+    # NixOS documentation server
+    nixos = {
+      enable = true;
+    };
+  };
+
+  # Extra settings that will be merged into the config
+  # OpenCode supports additional config like keybinds, lsp, etc.
+  settings = {
+    "$schema" = "https://opencode.ai/config.json";
+  };
+}

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -24,11 +24,13 @@ in
 
         flavorNames = [
           "claude-code"
+          "opencode"
           "vscode-workspace"
         ];
 
         flavorFormatMap = {
           claude-code = "json";
+          opencode = "json";
           vscode-workspace = "json";
         };
 
@@ -87,6 +89,7 @@ in
             fileName =
               {
                 claude-code = ".mcp.json";
+                opencode = "opencode.json";
                 vscode-workspace = ".vscode/mcp.json";
               }
               .${flavor};

--- a/modules/config.nix
+++ b/modules/config.nix
@@ -23,6 +23,7 @@
         "claude"
         "claude-code"
         "codex"
+        "opencode"
         "vscode"
         "vscode-workspace"
         "zed"
@@ -33,6 +34,7 @@
         - "claude": Standard Claude Desktop configuration format using "mcpServers" key
         - "claude-code": Claude Code configuration format using "mcpServers" key
         - "codex": Codex CLI configuration format using "mcp_servers" key
+        - "opencode": OpenCode configuration format using "mcp" key with command as array
         - "vscode": VSCode global configuration format using "mcp.servers" keys
         - "vscode-workspace": VSCode workspace configuration format with top-level "servers" key,
         - "zed": Zed configuration format with top-level "context_servers" key,
@@ -65,6 +67,8 @@
       keys =
         if (config.flavor == "codex") then
           [ "mcp_servers" ]
+        else if (config.flavor == "opencode") then
+          [ "mcp" ]
         else if (config.flavor == "vscode") then
           [
             "mcp"
@@ -76,11 +80,58 @@
           [ "context_servers" ]
         else
           [ "mcpServers" ];
+
+      # Transform server config for OpenCode format
+      # OpenCode uses: command (array), environment (not env), type "local"/"remote", enabled
+      transformForOpenCode =
+        name: server:
+        let
+          serverType = server.type or null;
+          # Combine command and args into a single command array
+          commandArray =
+            if server ? command && server.command != null then
+              [ server.command ] ++ (server.args or [ ])
+            else
+              [ ];
+          # Map stdio -> local, http/sse -> remote
+          opencodeType = if serverType == "stdio" || serverType == null then "local" else "remote";
+          # For remote servers, we need url instead of command
+          isRemote = serverType == "http" || serverType == "sse";
+          serverEnv = server.env or { };
+          serverHeaders = server.headers or { };
+          serverUrl = server.url or null;
+        in
+        lib.filterAttrs (k: v: v != null && v != { } && v != [ ]) (
+          {
+            type = opencodeType;
+            enabled = true;
+          }
+          // (
+            if isRemote then
+              {
+                url = serverUrl;
+                headers = serverHeaders;
+              }
+            else
+              {
+                command = commandArray;
+              }
+          )
+          // lib.optionalAttrs (serverEnv != { }) {
+            environment = serverEnv;
+          }
+        );
+
+      # Apply transformation if opencode flavor
+      serverConfig =
+        if config.flavor == "opencode" then
+          lib.mapAttrs transformForOpenCode config.settings.servers
+        else
+          config.settings.servers;
     in
     {
       configFile =
         let
-          serverConfig = config.settings.servers;
           extraConfig = lib.removeAttrs config.settings [ "servers" ];
           format = pkgs.formats.${config.format} { };
         in

--- a/tests/opencode.nix
+++ b/tests/opencode.nix
@@ -1,0 +1,54 @@
+# Test for OpenCode flavor configuration
+# OpenCode uses a different format: "mcp" key, array commands, "type": "local"/"remote"
+{ pkgs }:
+let
+  inherit (import ../lib) mkConfig;
+  # Create a test configuration for OpenCode
+  testConfig = mkConfig pkgs {
+    flavor = "opencode";
+    fileName = "opencode.json";
+
+    programs = {
+      filesystem = {
+        enable = true;
+        args = [ "/test/path" ];
+      };
+      fetch.enable = true;
+    };
+  };
+in
+{
+  test-opencode-format =
+    pkgs.runCommand "test-opencode-format"
+      {
+        nativeBuildInputs = with pkgs; [ jq ];
+      }
+      ''
+        # Verify the config has the correct OpenCode structure
+        config=$(cat ${testConfig})
+
+        # Check that "mcp" key exists (not "mcpServers")
+        echo "$config" | jq -e '.mcp' > /dev/null || (echo "FAIL: missing 'mcp' key" && exit 1)
+
+        # Check that mcpServers does NOT exist
+        if echo "$config" | jq -e '.mcpServers' > /dev/null 2>&1; then
+          echo "FAIL: should not have 'mcpServers' key"
+          exit 1
+        fi
+
+        # Check filesystem server has correct OpenCode format
+        echo "$config" | jq -e '.mcp.filesystem.command | type == "array"' > /dev/null || (echo "FAIL: command should be array" && exit 1)
+        echo "$config" | jq -e '.mcp.filesystem.type == "local"' > /dev/null || (echo "FAIL: type should be 'local'" && exit 1)
+        echo "$config" | jq -e '.mcp.filesystem.enabled == true' > /dev/null || (echo "FAIL: enabled should be true" && exit 1)
+
+        # Check fetch server exists
+        echo "$config" | jq -e '.mcp.fetch' > /dev/null || (echo "FAIL: missing fetch server" && exit 1)
+
+        # Check that args are included in command array for filesystem
+        echo "$config" | jq -e '.mcp.filesystem.command | length > 1' > /dev/null || (echo "FAIL: args should be in command array" && exit 1)
+        echo "$config" | jq -e '.mcp.filesystem.command[-1] == "/test/path"' > /dev/null || (echo "FAIL: args not correctly appended" && exit 1)
+
+        echo "All OpenCode format tests passed!"
+        touch $out
+      '';
+}


### PR DESCRIPTION
## Summary

Add support for [OpenCode](https://opencode.ai) MCP configuration format, a terminal-based AI coding assistant similar to Claude Code.

## Changes

- **modules/config.nix**: Added `"opencode"` to flavor enum and `transformForOpenCode` function
- **examples/opencode.nix**: Example configuration demonstrating OpenCode usage
- **tests/opencode.nix**: Tests validating the OpenCode format output
- **README.md**: Documentation for OpenCode CLI integration

## OpenCode Format Differences

OpenCode uses a different MCP configuration structure than Claude:

| Aspect | Claude/Claude Code | OpenCode |
|--------|-------------------|----------|
| Root key | `mcpServers` | `mcp` |
| Command | `"command": "cmd"` + `"args": []` | `"command": ["cmd", "arg1"]` (array) |
| Env vars | `env` | `environment` |
| Type | `stdio`/`http`/`sse` | `local`/`remote` |
| Enabled | not present | `enabled: true` |

## Example Output

```json
{
  "mcp": {
    "filesystem": {
      "command": ["/nix/store/.../mcp-server-filesystem", "/path/to/dir"],
      "enabled": true,
      "type": "local"
    },
    "fetch": {
      "command": ["/nix/store/.../mcp-server-fetch"],
      "enabled": true,
      "type": "local"
    }
  }
}
```

## Testing

All existing tests pass, plus the new `tests/opencode.nix` validates:
- Correct root key (`mcp` not `mcpServers`)
- Command is array format
- Type is `local` for stdio servers
- `enabled: true` is present
- Args are correctly appended to command array