### PR TITLE
feat: add google-calendar-mcp community package and module

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The output format adapts to the `flavor` option — see [Supported Flavors](#sup
 - [freee](./modules/servers/freee.nix)
 - [git](./modules/servers/git.nix)
 - [github](./modules/servers/github.nix)
+- [google-calendar](./modules/servers/google-calendar.nix)
 - [grafana](./modules/servers/grafana.nix)
 - [mastra](./modules/servers/mastra.nix)
 - [memory](./modules/servers/memory.nix)

--- a/docs/module-options.md
+++ b/docs/module-options.md
@@ -3005,6 +3005,271 @@ null
 
 
 
+## programs\.google-calendar\.enable
+
+
+
+Whether to enable google-calendar\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+
+
+*Example:*
+
+```nix
+true
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/google-calendar\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/google-calendar.nix)
+
+
+
+## programs\.google-calendar\.package
+
+
+
+The google-calendar-mcp package to use\.
+
+
+
+*Type:*
+package
+
+
+
+*Default:*
+
+```nix
+pkgs.google-calendar-mcp
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/google-calendar\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/google-calendar.nix)
+
+
+
+## programs\.google-calendar\.args
+
+
+
+Array of arguments passed to the command\.
+
+
+
+*Type:*
+list of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+[ ]
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/google-calendar\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/google-calendar.nix)
+
+
+
+## programs\.google-calendar\.env
+
+
+
+Environment variables for the server\.
+For security reasons, do not hardcode your credentials in the env\.
+All files in /nix/store can be read by anyone with access to the store\.
+Always use envFile instead\.
+
+
+
+*Type:*
+attribute set of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/google-calendar\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/google-calendar.nix)
+
+
+
+## programs\.google-calendar\.envFile
+
+
+
+Path to an \.env from which to load additional environment variables\.
+When flavor is set to ‘vscode’, the environment file is passed directly as a parameter instead of wrapping by default\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/google-calendar\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/google-calendar.nix)
+
+
+
+## programs\.google-calendar\.headers
+
+
+
+HTTP headers for authentication\.
+Used with “http” and “sse” transport types\.
+For security reasons, do not hardcode credentials in headers\.
+Use variable expansion syntax (e\.g\., ${VAR}) supported by the client\.
+Set environment variables before launching the client instead\.
+
+
+
+*Type:*
+attribute set of string
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+```nix
+{ Authorization = "Bearer \${API_TOKEN}"; }
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/google-calendar\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/google-calendar.nix)
+
+
+
+## programs\.google-calendar\.passwordCommand
+
+
+
+Command to execute to retrieve secrets\. Can be specified in two ways:
+
+ 1. As a string: The command should output in the format “KEY=VALUE” which will be exported as environment variables\.
+    Example: “pass mcp-server”
+
+ 2. As an attribute set: Keys are environment variable names and values are command lists that output the value\.
+    Example: { GITHUB_PERSONAL_ACCESS_TOKEN = \[ “gh” “auth” “token” ]; }
+
+This is useful for integrating with password managers or similar tools\.
+passwordCommand is always handled via the wrapper regardless of flavor\.
+
+
+
+*Type:*
+null or string or attribute set of list of string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+
+
+*Example:*
+
+```nix
+{
+  GITHUB_PERSONAL_ACCESS_TOKEN = [
+    "gh"
+    "auth"
+    "token"
+  ];
+}
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/google-calendar\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/google-calendar.nix)
+
+
+
+## programs\.google-calendar\.type
+
+
+
+Server connection type\.
+
+
+
+*Type:*
+null or one of “http”, “sse”, “stdio”
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/google-calendar\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/google-calendar.nix)
+
+
+
+## programs\.google-calendar\.url
+
+
+
+URL of the server (for “http” and “sse”)\.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/google-calendar\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/google-calendar.nix)
+
+
+
 ## programs\.grafana\.enable
 
 
@@ -5611,8 +5876,6 @@ attribute set of (boolean or signed integer or string)
 
 ## programs\.slite\.envFile
 
-
-
 Path to an \.env from which to load additional environment variables\.
 When flavor is set to ‘vscode’, the environment file is passed directly as a parameter instead of wrapping by default\.
 
@@ -5874,6 +6137,8 @@ list of (boolean or signed integer or string)
 
 
 ## programs\.tavily\.env
+
+
 
 Environment variables for the server\.
 For security reasons, do not hardcode your credentials in the env\.

--- a/modules/servers/google-calendar.nix
+++ b/modules/servers/google-calendar.nix
@@ -1,0 +1,4 @@
+{ mkServerModule, ... }:
+{
+  imports = [ (mkServerModule { name = "google-calendar"; packageName = "google-calendar-mcp"; }) ];
+}

--- a/pkgs/community/google-calendar-mcp/default.nix
+++ b/pkgs/community/google-calendar-mcp/default.nix
@@ -21,7 +21,7 @@ buildNpmPackage rec {
     description = "MCP integration for Google Calendar to manage events";
     homepage = "https://github.com/nspady/google-calendar-mcp";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ antono ];
     mainProgram = "google-calendar-mcp";
   };
 }

--- a/pkgs/community/google-calendar-mcp/default.nix
+++ b/pkgs/community/google-calendar-mcp/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+}:
+
+buildNpmPackage rec {
+  pname = "google-calendar-mcp";
+  version = "2.6.1";
+
+  src = fetchFromGitHub {
+    owner = "nspady";
+    repo = "google-calendar-mcp";
+    rev = "v${version}";
+    hash = "sha256-kfLJKeCwZxEnn6+pRIFNSp77b3N44dQKF6qVrDwdFyg=";
+  };
+
+  npmDepsHash = "sha256-ejXTesfoTHzNxbS3Ay/PlEye1KvNw+/4h+0hBObtO8E=";
+
+  meta = {
+    description = "MCP integration for Google Calendar to manage events";
+    homepage = "https://github.com/nspady/google-calendar-mcp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "google-calendar-mcp";
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -41,5 +41,6 @@ in
   slite-mcp-server = pkgs.callPackage ./official/slite { };
 
   # community servers
+  google-calendar-mcp = pkgs.callPackage ./community/google-calendar-mcp { };
   clickup-mcp-server = warnRemoved "clickup-mcp-server has been removed since upstream stopped distribution and switched to shareware";
 }


### PR DESCRIPTION
## Summary
- Added `google-calendar-mcp` as a community package using `buildNpmPackage`.
- Implemented `google-calendar` server module using the `mkServerModule` helper.
- Regenerated `docs/module-options.md` to include new configuration options.
- Set `antono` as the maintainer for the new package.