### PR TITLE
Add chrome-devtools-mcp server package and module

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The output format adapts to the `flavor` option — see [Supported Flavors](#sup
 
 ## Available Modules
 
+- [chrome-devtools](./modules/servers/chrome-devtools.nix)
 - [clickup](./modules/servers/clickup.nix)
 - [codex](./modules/servers/codex.nix)
 - [context7](./modules/servers/context7.nix)

--- a/docs/module-options.md
+++ b/docs/module-options.md
@@ -92,6 +92,271 @@ one of “json”, “yaml”, “toml”, “toml-inline”
 
 
 
+## programs\.chrome-devtools\.enable
+
+
+
+Whether to enable chrome-devtools\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+
+
+*Example:*
+
+```nix
+true
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.package
+
+
+
+The chrome-devtools-mcp package to use\.
+
+
+
+*Type:*
+package
+
+
+
+*Default:*
+
+```nix
+pkgs.chrome-devtools-mcp
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.args
+
+
+
+Array of arguments passed to the command\.
+
+
+
+*Type:*
+list of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+[ ]
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.env
+
+
+
+Environment variables for the server\.
+For security reasons, do not hardcode your credentials in the env\.
+All files in /nix/store can be read by anyone with access to the store\.
+Always use envFile instead\.
+
+
+
+*Type:*
+attribute set of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.envFile
+
+
+
+Path to an \.env from which to load additional environment variables\.
+When flavor is set to ‘vscode’, the environment file is passed directly as a parameter instead of wrapping by default\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.headers
+
+
+
+HTTP headers for authentication\.
+Used with “http” and “sse” transport types\.
+For security reasons, do not hardcode credentials in headers\.
+Use variable expansion syntax (e\.g\., ${VAR}) supported by the client\.
+Set environment variables before launching the client instead\.
+
+
+
+*Type:*
+attribute set of string
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+```nix
+{ Authorization = "Bearer \${API_TOKEN}"; }
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.passwordCommand
+
+
+
+Command to execute to retrieve secrets\. Can be specified in two ways:
+
+ 1. As a string: The command should output in the format “KEY=VALUE” which will be exported as environment variables\.
+    Example: “pass mcp-server”
+
+ 2. As an attribute set: Keys are environment variable names and values are command lists that output the value\.
+    Example: { GITHUB_PERSONAL_ACCESS_TOKEN = \[ “gh” “auth” “token” ]; }
+
+This is useful for integrating with password managers or similar tools\.
+passwordCommand is always handled via the wrapper regardless of flavor\.
+
+
+
+*Type:*
+null or string or attribute set of list of string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+
+
+*Example:*
+
+```nix
+{
+  GITHUB_PERSONAL_ACCESS_TOKEN = [
+    "gh"
+    "auth"
+    "token"
+  ];
+}
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.type
+
+
+
+Server connection type\.
+
+
+
+*Type:*
+null or one of “http”, “sse”, “stdio”
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.url
+
+
+
+URL of the server (for “http” and “sse”)\.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
 ## programs\.clickup\.enable
 
 
@@ -2648,8 +2913,6 @@ attribute set of string
 
 ## programs\.git\.passwordCommand
 
-
-
 Command to execute to retrieve secrets\. Can be specified in two ways:
 
  1. As a string: The command should output in the format “KEY=VALUE” which will be exported as environment variables\.
@@ -2912,6 +3175,8 @@ attribute set of string
 
 
 ## programs\.github\.passwordCommand
+
+
 
 Command to execute to retrieve secrets\. Can be specified in two ways:
 
@@ -5611,8 +5876,6 @@ attribute set of (boolean or signed integer or string)
 
 ## programs\.slite\.envFile
 
-
-
 Path to an \.env from which to load additional environment variables\.
 When flavor is set to ‘vscode’, the environment file is passed directly as a parameter instead of wrapping by default\.
 
@@ -5874,6 +6137,8 @@ list of (boolean or signed integer or string)
 
 
 ## programs\.tavily\.env
+
+
 
 Environment variables for the server\.
 For security reasons, do not hardcode your credentials in the env\.

--- a/modules/servers/chrome-devtools.nix
+++ b/modules/servers/chrome-devtools.nix
@@ -1,0 +1,9 @@
+{ mkServerModule, ... }:
+{
+  imports = [
+    (mkServerModule {
+      name = "chrome-devtools";
+      packageName = "chrome-devtools-mcp";
+    })
+  ];
+}

--- a/pkgs/community/chrome-devtools/default.nix
+++ b/pkgs/community/chrome-devtools/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  nodejs,
+}:
+
+let
+  version = "0.20.3";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-${version}.tgz";
+    sha256 = "1vz22g7cddwnd594la3i6v23hx90dbm2khabx7ncqsmnb9v5nzv1";
+  };
+in
+stdenv.mkDerivation {
+  pname = "chrome-devtools-mcp";
+  inherit version src;
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    tar -xzf $src
+
+    mkdir -p $out/lib/chrome-devtools-mcp
+    cp -r package/* $out/lib/chrome-devtools-mcp/
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/chrome-devtools-mcp \
+      --add-flags "$out/lib/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js" \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+      --set NODE_PATH "$out/lib/chrome-devtools-mcp/node_modules"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Chrome DevTools MCP server for AI coding agents";
+    homepage = "https://github.com/ChromeDevTools/chrome-devtools-mcp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ natsukium ];
+    mainProgram = "chrome-devtools-mcp";
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -41,5 +41,6 @@ in
   slite-mcp-server = pkgs.callPackage ./official/slite { };
 
   # community servers
+  chrome-devtools-mcp = pkgs.callPackage ./community/chrome-devtools { };
   clickup-mcp-server = warnRemoved "clickup-mcp-server has been removed since upstream stopped distribution and switched to shareware";
 }


### PR DESCRIPTION
## Summary
- Add `chrome-devtools-mcp` package at `pkgs/community/chrome-devtools/default.nix`
- Uses npm tarball (v0.20.3) with bundled JavaScript to avoid TypeScript build issues
- Add corresponding NixOS/home-manager module at `modules/servers/chrome-devtools.nix`
- Register package in `pkgs/default.nix`

## Changes
- Package uses the published npm tarball with pre-built JavaScript
- Module uses the standard `mkServerModule` helper
- Tested: binary runs and shows help text correctly

## Testing
- `nix-instantiate` evaluates correctly
- Package builds successfully
- Binary executes and shows usage