### PR TITLE
🎉 Feature: add greenhouse-mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The output format adapts to the `flavor` option — see [Supported Flavors](#sup
 - [git](./modules/servers/git.nix)
 - [github](./modules/servers/github.nix)
 - [grafana](./modules/servers/grafana.nix)
+- [greenhouse](./modules/servers/greenhouse.nix)
 - [mastra](./modules/servers/mastra.nix)
 - [memory](./modules/servers/memory.nix)
 - [netdata](./modules/servers/netdata.nix)

--- a/modules/servers/greenhouse.nix
+++ b/modules/servers/greenhouse.nix
@@ -1,0 +1,9 @@
+{ mkServerModule, ... }:
+{
+  imports = [
+    (mkServerModule {
+      name = "greenhouse";
+      packageName = "greenhouse-mcp";
+    })
+  ];
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -30,6 +30,7 @@ in
   deepl-mcp-server = pkgs.callPackage ./official/deepl { };
   esa-mcp-server = pkgs.callPackage ./official/esa { };
   freee-mcp = pkgs.callPackage ./official/freee { };
+  greenhouse-mcp = pkgs.callPackage ./official/greenhouse { };
   mastra-mcp-docs-server = pkgs.callPackage ./official/mastra { };
   nd-mcp = pkgs.callPackage ./official/netdata { };
   tavily-mcp = pkgs.callPackage ./official/tavily { };

--- a/pkgs/official/greenhouse/default.nix
+++ b/pkgs/official/greenhouse/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchzip,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "greenhouse-mcp";
+  version = "0.1.0";
+
+  src = fetchzip {
+    url = "https://github.com/alexmeckes/greenhouse-mcp/archive/refs/heads/main.tar.gz";
+    hash = "sha256-+Fgct4Z7eHAGUyqv3SZddCsHKTQlT/tEX6joV+NFWqs=";
+  };
+
+  format = "pyproject";
+
+  dependencies = with python3Packages; [
+    fastmcp
+    httpx
+    pydantic
+    python-dotenv
+  ];
+
+  dontCheckPythonImports = true;
+
+  meta = with lib; {
+    description = "MCP server for Greenhouse Harvest API";
+    homepage = "https://github.com/alexmeckes/greenhouse-mcp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+    mainProgram = "greenhouse-mcp";
+  };
+}


### PR DESCRIPTION
- Add Python-based MCP server for Greenhouse Harvest API
- Provides tools for jobs, candidates, applications, and organization data
- Include Nix package and NixOS/Home Manager module