### PR TITLE
🎉 Feature: Add SigNoz MCP Server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The output format adapts to the `flavor` option — see [Supported Flavors](#sup
 - [playwright](./modules/servers/playwright.nix)
 - [sequential-thinking](./modules/servers/sequential-thinking.nix)
 - [serena](./modules/servers/serena.nix)
+- [signoz](./modules/servers/signoz.nix)
 - [slite](./modules/servers/slite.nix)
 - [tavily](./modules/servers/tavily.nix)
 - [terraform](./modules/servers/terraform.nix)
@@ -101,6 +102,7 @@ The output format adapts to the `flavor` option — see [Supported Flavors](#sup
 Check the `examples` directory for complete configuration examples:
 
 - [`claude-desktop.nix`](./examples/claude-desktop.nix): Basic configuration for Claude Desktop
+- [`signoz.nix`](./examples/signoz.nix): SigNoz observability with passwordCommand
 - [`vscode.nix`](./examples/vscode.nix): VS Code integration setup
 - [`librechat.nix`](./examples/librechat.nix): Configuration for LibreChat integration
 - [`codex.nix`](./examples/codex.nix): Codex CLI integration with MCP servers

--- a/docs/module-options.md
+++ b/docs/module-options.md
@@ -5502,6 +5502,271 @@ null
 
 
 
+## programs\.signoz\.enable
+
+
+
+Whether to enable signoz\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+
+
+*Example:*
+
+```nix
+true
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/signoz\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/signoz.nix)
+
+
+
+## programs\.signoz\.package
+
+
+
+The signoz-mcp-server package to use\.
+
+
+
+*Type:*
+package
+
+
+
+*Default:*
+
+```nix
+pkgs.signoz-mcp-server
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/signoz\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/signoz.nix)
+
+
+
+## programs\.signoz\.args
+
+
+
+Array of arguments passed to the command\.
+
+
+
+*Type:*
+list of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+[ ]
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/signoz\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/signoz.nix)
+
+
+
+## programs\.signoz\.env
+
+
+
+Environment variables for the server\.
+For security reasons, do not hardcode your credentials in the env\.
+All files in /nix/store can be read by anyone with access to the store\.
+Always use envFile instead\.
+
+
+
+*Type:*
+attribute set of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/signoz\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/signoz.nix)
+
+
+
+## programs\.signoz\.envFile
+
+
+
+Path to an \.env from which to load additional environment variables\.
+When flavor is set to ‘vscode’, the environment file is passed directly as a parameter instead of wrapping by default\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/signoz\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/signoz.nix)
+
+
+
+## programs\.signoz\.headers
+
+
+
+HTTP headers for authentication\.
+Used with “http” and “sse” transport types\.
+For security reasons, do not hardcode credentials in headers\.
+Use variable expansion syntax (e\.g\., ${VAR}) supported by the client\.
+Set environment variables before launching the client instead\.
+
+
+
+*Type:*
+attribute set of string
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+```nix
+{ Authorization = "Bearer \${API_TOKEN}"; }
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/signoz\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/signoz.nix)
+
+
+
+## programs\.signoz\.passwordCommand
+
+
+
+Command to execute to retrieve secrets\. Can be specified in two ways:
+
+ 1. As a string: The command should output in the format “KEY=VALUE” which will be exported as environment variables\.
+    Example: “pass mcp-server”
+
+ 2. As an attribute set: Keys are environment variable names and values are command lists that output the value\.
+    Example: { GITHUB_PERSONAL_ACCESS_TOKEN = \[ “gh” “auth” “token” ]; }
+
+This is useful for integrating with password managers or similar tools\.
+passwordCommand is always handled via the wrapper regardless of flavor\.
+
+
+
+*Type:*
+null or string or attribute set of list of string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+
+
+*Example:*
+
+```nix
+{
+  GITHUB_PERSONAL_ACCESS_TOKEN = [
+    "gh"
+    "auth"
+    "token"
+  ];
+}
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/signoz\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/signoz.nix)
+
+
+
+## programs\.signoz\.type
+
+
+
+Server connection type\.
+
+
+
+*Type:*
+null or one of “http”, “sse”, “stdio”
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/signoz\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/signoz.nix)
+
+
+
+## programs\.signoz\.url
+
+
+
+URL of the server (for “http” and “sse”)\.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/signoz\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/signoz.nix)
+
+
+
 ## programs\.slite\.enable
 
 
@@ -5610,8 +5875,6 @@ attribute set of (boolean or signed integer or string)
 
 
 ## programs\.slite\.envFile
-
-
 
 Path to an \.env from which to load additional environment variables\.
 When flavor is set to ‘vscode’, the environment file is passed directly as a parameter instead of wrapping by default\.
@@ -5874,6 +6137,8 @@ list of (boolean or signed integer or string)
 
 
 ## programs\.tavily\.env
+
+
 
 Environment variables for the server\.
 For security reasons, do not hardcode your credentials in the env\.

--- a/examples/signoz.nix
+++ b/examples/signoz.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+{
+  programs.signoz = {
+    enable = true;
+    env = {
+      SIGNOZ_URL = "https://your-tenant.signoz.cloud";
+    };
+    passwordCommand = {
+      SIGNOZ_API_KEY = [ "pass" "mcp/signoz" ];
+    };
+  };
+}

--- a/modules/servers/signoz.nix
+++ b/modules/servers/signoz.nix
@@ -1,0 +1,9 @@
+{ mkServerModule, ... }:
+{
+  imports = [
+    (mkServerModule {
+      name = "signoz";
+      packageName = "signoz-mcp-server";
+    })
+  ];
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -38,6 +38,7 @@ in
   playwright-mcp = pkgs.callPackage ./official/playwright { };
   github-mcp-server = warnRemoved "github-mcp-server has been removed since it is now available in the nixpkgs 25.11 stable release";
   serena = pkgs.callPackage ./official/serena { };
+  signoz-mcp-server = pkgs.callPackage ./official/signoz { };
   slite-mcp-server = pkgs.callPackage ./official/slite { };
 
   # community servers

--- a/pkgs/official/signoz/default.nix
+++ b/pkgs/official/signoz/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "signoz-mcp-server";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "SigNoz";
+    repo = "signoz-mcp-server";
+    rev = "v${finalAttrs.version}";
+    sha256 = "MpbYz1gsXg7+wBaNDGljn9TuyRsYwoZ8MFgR3/GgRNk=";
+  };
+
+  vendorHash = "sha256-MKm5he3bwwJUTCJ/L986lRGN0mYaWI5rOaeQyg/QeU8=";
+
+  postInstall = ''
+    mv $out/bin/server $out/bin/signoz-mcp-server
+  '';
+
+  meta = {
+    description = "MCP Server for SigNoz observability platform";
+    homepage = "https://github.com/SigNoz/signoz-mcp-server";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ antono ];
+    mainProgram = "signoz-mcp-server";
+  };
+})


### PR DESCRIPTION
## Summary
- Add signoz-mcp-server package (v0.1.0) - Go-based MCP server for SigNoz observability platform
- Add signoz module configuration using mkServerModule
- Add example configuration with passwordCommand for SIGNOZ_API_KEY
- Update README with new module and example
- Auto-generate module options documentation

## Changes
- `pkgs/official/signoz/default.nix` - Package definition for Go-based MCP server
- `modules/servers/signoz.nix` - Module config with standard options
- `pkgs/default.nix` - Package registration
- `examples/signoz.nix` - Usage example with passwordCommand
- `README.md` - Documentation update
- `docs/module-options.md` - Auto-generated options

## Testing
- Package builds successfully
- Config generation works with env and passwordCommand options
- Binary correctly renamed to `signoz-mcp-server`