### PR TITLE
reference-servers: 2025.12.18 -> 2026.1.26

### DIFF
--- a/pkgs/reference/generic-ts.nix
+++ b/pkgs/reference/generic-ts.nix
@@ -17,7 +17,7 @@ buildNpmPackage {
 
   nodejs = nodejs_22;
 
-  npmDepsHash = "sha256-wluSvNnZcIz2XyXqmmego+vYThT3EtzakJsamzhgb6g=";
+  npmDepsHash = "sha256-jmz4JdpeHH07vJQFntBwrENbJaIcOuZMb7+qf497VOE=";
 
   npmWorkspace = "src/${workspace}";
 

--- a/pkgs/reference/source.nix
+++ b/pkgs/reference/source.nix
@@ -1,10 +1,10 @@
 { fetchFromGitHub }:
 rec {
-  version = "2025.12.18";
+  version = "2026.1.26";
   src = fetchFromGitHub {
     owner = "modelcontextprotocol";
     repo = "servers";
     tag = version;
-    hash = "sha256-Km0MjjZhhijynYyju3tMJwsplrpNUr4cJ95TxqgrrR8=";
+    hash = "sha256-uULXUEHFZpYm/fmF6PkOFCxS+B+0q3dMveLG+3JHrhk=";
   };
 }


### PR DESCRIPTION
## Summary
- Bump `modelcontextprotocol/servers` to [2026.1.26](https://github.com/modelcontextprotocol/servers/releases/tag/2026.1.26)
- Update source hash and npmDepsHash accordingly

## Test plan
- [x] `nix build .#mcp-server-everything`
- [x] `nix build .#mcp-server-filesystem`
- [x] `nix build .#mcp-server-memory`
- [x] `nix build .#mcp-server-sequential-thinking`
- [x] `nix build .#mcp-server-fetch`
- [x] `nix build .#mcp-server-git`
- [x] `nix build .#mcp-server-time`