### PR TITLE
treewide: modernize nix code

### DIFF
--- a/pkgs/official/context7/default.nix
+++ b/pkgs/official/context7/default.nix
@@ -30,6 +30,8 @@ let
     dontFixup = true;
 
     installPhase = ''
+      runHook preInstall
+
       export HOME=$TMPDIR
 
       # Install dependencies
@@ -39,6 +41,8 @@ let
       mkdir -p $out
       cp -r node_modules $out/
       cp bun.lock package.json $out/
+
+      runHook postInstall
     '';
 
     # This hash represents the dependencies

--- a/pkgs/official/deepl/default.nix
+++ b/pkgs/official/deepl/default.nix
@@ -4,7 +4,7 @@
   buildNpmPackage,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "deepl-mcp-server";
   version = "1.1.0-unstable-2026-01-28";
 
@@ -26,4 +26,4 @@ buildNpmPackage rec {
     maintainers = with lib.maintainers; [ vaporif ];
     mainProgram = "deepl-mcp-server";
   };
-}
+})

--- a/pkgs/official/playwright/default.nix
+++ b/pkgs/official/playwright/default.nix
@@ -5,14 +5,14 @@
   versionCheckHook,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "playwright-mcp";
   version = "0.0.70";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "playwright-mcp";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-dvFFG+/cYy09RjEMDIWncTNCcyaKoKH52qweYq0HHxU=";
   };
 
@@ -35,9 +35,9 @@ buildNpmPackage rec {
   meta = {
     description = "Playwright MCP server";
     homepage = "https://github.com/microsoft/playwright-mcp";
-    changelog = "https://github.com/microsoft/playwright-mcp/releases/tag/v${version}";
+    changelog = "https://github.com/microsoft/playwright-mcp/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ natsukium ];
     mainProgram = "playwright-mcp";
   };
-}
+})

--- a/pkgs/official/serena/default.nix
+++ b/pkgs/official/serena/default.nix
@@ -8,7 +8,7 @@
   writableTmpDirAsHomeHook,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "serena";
   version = "0.1.4-unstable-2026-03-23";
   pyproject = true;
@@ -100,9 +100,9 @@ python3Packages.buildPythonApplication rec {
   meta = {
     description = "Powerful coding agent toolkit providing semantic retrieval and editing capabilities";
     homepage = "https://github.com/oraios/serena";
-    changelog = "https://github.com/oraios/serena/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/oraios/serena/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ natsukium ];
     mainProgram = "serena";
   };
-}
+})

--- a/pkgs/reference/generic-python.nix
+++ b/pkgs/reference/generic-python.nix
@@ -9,11 +9,11 @@
   doCheck ? true,
   nativeCheckInputs ? [ python3Packages.pytestCheckHook ],
 }:
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mcp-server-${service}";
   inherit (import ./source.nix { inherit fetchFromGitHub; }) version src;
   pyproject = true;
-  sourceRoot = "${src.name}/src/${service}";
+  sourceRoot = "${finalAttrs.src.name}/src/${service}";
   inherit
     build-system
     dependencies
@@ -31,4 +31,4 @@ python3Packages.buildPythonApplication rec {
     maintainers = with lib.maintainers; [ natsukium ];
     mainProgram = "mcp-server-${service}";
   };
-}
+})


### PR DESCRIPTION
## Summary
- Convert `rec` attribute sets to the `finalAttrs` pattern in `buildNpmPackage` / `buildPythonApplication` calls (`deepl`, `playwright`, `serena`, `generic-python`) so that `overrideAttrs` consistently sees updated attribute values.
- Add missing `runHook preInstall` / `runHook postInstall` calls to the `context7` deps derivation so setup hooks from `nativeBuildInputs` run as expected.

## Test plan
- [x] `nix flake check --no-build` evaluates successfully