### PR TITLE
ci: pass --subpackage deps for freee-mcp updates

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -47,6 +47,8 @@ jobs:
             NIX_UPDATE_FLAGS="--version=branch"
           elif [[ "${{ matrix.package }}" == "mastra-mcp-docs-server" ]]; then
             NIX_UPDATE_FLAGS='--version-regex @mastra/mcp-docs-server@(.*)'
+          elif [[ "${{ matrix.package }}" == "freee-mcp" ]]; then
+            NIX_UPDATE_FLAGS="--subpackage deps"
           else
             NIX_UPDATE_FLAGS=""
           fi


### PR DESCRIPTION
## Summary
- The freee-mcp package keeps its bun-installed `node_modules` in a separate fixed-output derivation (`deps`) with its own `outputHash`.
- `nix-update --flake` does **not** read `passthru.updateScript.extraArgs`, so even though `default.nix` passes `--subpackage deps` via `nix-update-script`, the workflow was bumping only the source hash and leaving the deps hash stale.
- Result: every version bump PR (most recently freee-mcp 0.24.0 → 0.25.0) failed to build until the deps hash was fixed by hand.

This patch passes `--subpackage deps` explicitly in the workflow for freee-mcp, mirroring the existing per-package overrides for serena and mastra-mcp-docs-server.

## Test plan
- [ ] Re-run the `Update packages` workflow for freee-mcp (or wait for the next scheduled run) and verify the resulting PR updates both `src` and `deps` hashes
- [ ] Confirm `nix build .#freee-mcp` succeeds on the auto-generated PR without manual intervention