### PR TITLE
ha-mcp: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The output format adapts to the `flavor` option — see [Supported Flavors](#sup
 - [git](./modules/servers/git.nix)
 - [github](./modules/servers/github.nix)
 - [grafana](./modules/servers/grafana.nix)
+- [ha-mcp](./modules/servers/ha-mcp.nix)
 - [mastra](./modules/servers/mastra.nix)
 - [memory](./modules/servers/memory.nix)
 - [netdata](./modules/servers/netdata.nix)

--- a/docs/module-options.md
+++ b/docs/module-options.md
@@ -3270,6 +3270,271 @@ null
 
 
 
+## programs\.ha-mcp\.enable
+
+
+
+Whether to enable ha-mcp\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+
+
+*Example:*
+
+```nix
+true
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+
+
+
+## programs\.ha-mcp\.package
+
+
+
+The ha-mcp package to use\.
+
+
+
+*Type:*
+package
+
+
+
+*Default:*
+
+```nix
+pkgs.ha-mcp
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+
+
+
+## programs\.ha-mcp\.args
+
+
+
+Array of arguments passed to the command\.
+
+
+
+*Type:*
+list of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+[ ]
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+
+
+
+## programs\.ha-mcp\.env
+
+
+
+Environment variables for the server\.
+For security reasons, do not hardcode your credentials in the env\.
+All files in /nix/store can be read by anyone with access to the store\.
+Always use envFile instead\.
+
+
+
+*Type:*
+attribute set of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+
+
+
+## programs\.ha-mcp\.envFile
+
+
+
+Path to an \.env from which to load additional environment variables\.
+When flavor is set to ‘vscode’, the environment file is passed directly as a parameter instead of wrapping by default\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+
+
+
+## programs\.ha-mcp\.headers
+
+
+
+HTTP headers for authentication\.
+Used with “http” and “sse” transport types\.
+For security reasons, do not hardcode credentials in headers\.
+Use variable expansion syntax (e\.g\., ${VAR}) supported by the client\.
+Set environment variables before launching the client instead\.
+
+
+
+*Type:*
+attribute set of string
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+```nix
+{ Authorization = "Bearer \${API_TOKEN}"; }
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+
+
+
+## programs\.ha-mcp\.passwordCommand
+
+
+
+Command to execute to retrieve secrets\. Can be specified in two ways:
+
+ 1. As a string: The command should output in the format “KEY=VALUE” which will be exported as environment variables\.
+    Example: “pass mcp-server”
+
+ 2. As an attribute set: Keys are environment variable names and values are command lists that output the value\.
+    Example: { GITHUB_PERSONAL_ACCESS_TOKEN = \[ “gh” “auth” “token” ]; }
+
+This is useful for integrating with password managers or similar tools\.
+passwordCommand is always handled via the wrapper regardless of flavor\.
+
+
+
+*Type:*
+null or string or attribute set of list of string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+
+
+*Example:*
+
+```nix
+{
+  GITHUB_PERSONAL_ACCESS_TOKEN = [
+    "gh"
+    "auth"
+    "token"
+  ];
+}
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+
+
+
+## programs\.ha-mcp\.type
+
+
+
+Server connection type\.
+
+
+
+*Type:*
+null or one of “http”, “sse”, “stdio”
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+
+
+
+## programs\.ha-mcp\.url
+
+
+
+URL of the server (for “http” and “sse”)\.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+
+
+
 ## programs\.mastra\.enable
 
 
@@ -5654,8 +5919,6 @@ pkgs.tavily-mcp
 
 ## programs\.tavily\.args
 
-
-
 Array of arguments passed to the command\.
 
 
@@ -5918,6 +6181,8 @@ pkgs.terraform-mcp-server
 
 
 ## programs\.terraform\.args
+
+
 
 Array of arguments passed to the command\.
 

--- a/modules/servers/ha-mcp.nix
+++ b/modules/servers/ha-mcp.nix
@@ -1,0 +1,9 @@
+{ mkServerModule, ... }:
+{
+  imports = [
+    (mkServerModule {
+      name = "ha-mcp";
+      packageName = "ha-mcp";
+    })
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `programs.ha-mcp` module backed by the existing nixpkgs `ha-mcp` package (Home Assistant MCP server).
- Minimal `mkServerModule` setup — credentials (`HOMEASSISTANT_URL`, `HOMEASSISTANT_TOKEN`) are configured by users via `env` / `envFile` / `passwordCommand`, matching the pattern used by `grafana` and `freee`.
- Update README module list and regenerate `docs/module-options.md`.

## Test plan
- [x] `nix-build` evaluation of `mkConfig` with `programs.ha-mcp.enable = true` produces a valid `claude_desktop_config.json` referencing `ha-mcp` from nixpkgs.
- [x] `docs/module-options.md` regenerated via `nix-build docs/options-doc.nix -A optionsCommonMark`.