### PR TITLE
ha-mcp: rename module to home-assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The output format adapts to the `flavor` option — see [Supported Flavors](#sup
 - [git](./modules/servers/git.nix)
 - [github](./modules/servers/github.nix)
 - [grafana](./modules/servers/grafana.nix)
-- [ha-mcp](./modules/servers/ha-mcp.nix)
+- [home-assistant](./modules/servers/home-assistant.nix)
 - [mastra](./modules/servers/mastra.nix)
 - [memory](./modules/servers/memory.nix)
 - [netdata](./modules/servers/netdata.nix)

--- a/docs/module-options.md
+++ b/docs/module-options.md
@@ -3270,11 +3270,11 @@ null
 
 
 
-## programs\.ha-mcp\.enable
+## programs\.home-assistant\.enable
 
 
 
-Whether to enable ha-mcp\.
+Whether to enable home-assistant\.
 
 
 
@@ -3298,11 +3298,11 @@ true
 ```
 
 *Declared by:*
- - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+ - [\<mcp-servers-nix/modules/servers/home-assistant\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/home-assistant.nix)
 
 
 
-## programs\.ha-mcp\.package
+## programs\.home-assistant\.package
 
 
 
@@ -3322,11 +3322,11 @@ pkgs.ha-mcp
 ```
 
 *Declared by:*
- - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+ - [\<mcp-servers-nix/modules/servers/home-assistant\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/home-assistant.nix)
 
 
 
-## programs\.ha-mcp\.args
+## programs\.home-assistant\.args
 
 
 
@@ -3346,11 +3346,11 @@ list of (boolean or signed integer or string)
 ```
 
 *Declared by:*
- - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+ - [\<mcp-servers-nix/modules/servers/home-assistant\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/home-assistant.nix)
 
 
 
-## programs\.ha-mcp\.env
+## programs\.home-assistant\.env
 
 
 
@@ -3373,11 +3373,11 @@ attribute set of (boolean or signed integer or string)
 ```
 
 *Declared by:*
- - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+ - [\<mcp-servers-nix/modules/servers/home-assistant\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/home-assistant.nix)
 
 
 
-## programs\.ha-mcp\.envFile
+## programs\.home-assistant\.envFile
 
 
 
@@ -3398,11 +3398,11 @@ null
 ```
 
 *Declared by:*
- - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+ - [\<mcp-servers-nix/modules/servers/home-assistant\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/home-assistant.nix)
 
 
 
-## programs\.ha-mcp\.headers
+## programs\.home-assistant\.headers
 
 
 
@@ -3435,11 +3435,11 @@ attribute set of string
 ```
 
 *Declared by:*
- - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+ - [\<mcp-servers-nix/modules/servers/home-assistant\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/home-assistant.nix)
 
 
 
-## programs\.ha-mcp\.passwordCommand
+## programs\.home-assistant\.passwordCommand
 
 
 
@@ -3483,11 +3483,11 @@ null
 ```
 
 *Declared by:*
- - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+ - [\<mcp-servers-nix/modules/servers/home-assistant\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/home-assistant.nix)
 
 
 
-## programs\.ha-mcp\.type
+## programs\.home-assistant\.type
 
 
 
@@ -3507,11 +3507,11 @@ null
 ```
 
 *Declared by:*
- - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+ - [\<mcp-servers-nix/modules/servers/home-assistant\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/home-assistant.nix)
 
 
 
-## programs\.ha-mcp\.url
+## programs\.home-assistant\.url
 
 
 
@@ -3531,7 +3531,7 @@ null
 ```
 
 *Declared by:*
- - [\<mcp-servers-nix/modules/servers/ha-mcp\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/ha-mcp.nix)
+ - [\<mcp-servers-nix/modules/servers/home-assistant\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/home-assistant.nix)
 
 
 

--- a/modules/servers/home-assistant.nix
+++ b/modules/servers/home-assistant.nix
@@ -2,7 +2,7 @@
 {
   imports = [
     (mkServerModule {
-      name = "ha-mcp";
+      name = "home-assistant";
       packageName = "ha-mcp";
     })
   ];


### PR DESCRIPTION
## Summary
- Rename module `ha-mcp` to `home-assistant` (file, `name`, README link, regenerated docs)
- Keep `packageName = "ha-mcp"` so the upstream package reference is unchanged
- Users now enable via `programs.home-assistant.enable`

## Why
Every other module in this repo uses the **service/product name** as the module name, with the upstream package name carried in `packageName`:

| Module name | Package name |
|---|---|
| `playwright` | `playwright-mcp` |
| `context7` | `context7-mcp` |
| `grafana` | `mcp-grafana` |
| `nixos` | `mcp-nixos` |
| `notion` | `notion-mcp-server` |
| `github` | `github-mcp-server` |
| `tavily` | `tavily-mcp` |
| `netdata` | `nd-mcp` |
| `terraform` | `terraform-mcp-server` |

`ha-mcp` was the only module that bled the `-mcp` suffix into its module name. This PR aligns it with the convention.

The module was just added in 8b6a65c and is unreleased, so no compat shim is needed.

## Test plan
- [x] `nix build .#checks.<system>.module-options-doc` passes (regenerated `docs/module-options.md` matches)
- [x] `git grep "ha-mcp"` only matches `packageName = "ha-mcp"` and `pkgs.ha-mcp` references in regenerated docs