### PR TITLE
serena: restrict auto-update to v-prefixed tags

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -45,7 +45,11 @@ jobs:
         id: update-package
         run: |
           if [[ "${{ matrix.package }}" == "serena" ]]; then
-            NIX_UPDATE_FLAGS="--version=branch"
+            # Restrict to v-prefixed semver tags; upstream also ships
+            # legacy date-named tags (e.g. 2025-06-20) that otherwise
+            # land at the head of the releases atom feed and get picked
+            # as the "version" portion of the unstable string.
+            NIX_UPDATE_FLAGS='--version=branch --version-regex v(.*)'
           elif [[ "${{ matrix.package }}" == "mastra-mcp-docs-server" ]]; then
             NIX_UPDATE_FLAGS='--version-regex @mastra/mcp-docs-server@(.*)'
           elif [[ "${{ matrix.package }}" == "freee-mcp" ]]; then

--- a/pkgs/official/serena/default.nix
+++ b/pkgs/official/serena/default.nix
@@ -65,7 +65,7 @@ let
 in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "serena";
-  version = "2025-06-20-unstable-2026-05-10";
+  version = "1.2.0-unstable-2026-05-10";
   pyproject = true;
 
   src = fetchFromGitHub {


### PR DESCRIPTION
## Summary

- `nix-update --version=branch` builds the candidate list from the GitHub releases atom feed and returns `final[0]`. Upstream serena ships both v-prefixed semver tags and legacy date-named tags (`2025-04-01`, `2025-06-20`, ...); when the latter happen to land at the head of the feed response, the auto-update commits a version like `2025-06-20-unstable-<date>` instead of `1.2.0-unstable-<date>` (#450).
- Add `--version-regex 'v(.*)'` to the serena branch in `.github/workflows/update-packages.yml` so only v-prefixed tags qualify.
- Fix the stale version label that the previous auto-update committed.

## Test plan

- [x] Reproduce: with `version = "2025-06-20-unstable-2026-05-10"` and the new regex, `nix-update --flake serena --version=branch --version-regex 'v(.*)'` rewrites to `1.2.0-unstable-2026-05-10`.
- [x] Verify shell quoting: `bash -c 'NIX_UPDATE_FLAGS=...; nix-update $NIX_UPDATE_FLAGS'` splits to three argv entries (`--version=branch`, `--version-regex`, `v(.*)`).
- [x] `nix eval .#serena.version` resolves to the corrected label.