### PR TITLE
ci: drop x86_64-darwin from check matrix

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-latest ]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Why

nixpkgs support for x86_64-darwin ended after 26.05, so testing on the `macos-15-intel` runner no longer provides meaningful coverage.

## What

Remove `macos-15-intel` from the check job matrix. Remaining targets: `ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest` (aarch64-darwin).