### PR TITLE
examples/opencode: drop nixos server from the example

### DIFF
--- a/examples/opencode.nix
+++ b/examples/opencode.nix
@@ -31,11 +31,6 @@ mcp-servers.lib.mkConfig pkgs {
     fetch = {
       enable = true;
     };
-
-    # NixOS documentation server
-    nixos = {
-      enable = true;
-    };
   };
 
   # Extra settings that will be merged into the config


### PR DESCRIPTION
## Why

Since #492 (nixpkgs bump), CI has been failing on macOS runners, blocking the PR queue. The failure comes from `mcp-nixos`'s test suite:

```
tests/test_store.py::TestStoreReadTextFile::test_read_text_file
  assert "Error" not in result
  AssertionError: assert 'Error' not in 'File: /nix/...69\n    }\n]'
  1 failed, 282 passed
```

This test is **non-deterministic**: it picks the first entry from `os.listdir("/nix/store")` and the first text file under it (`os.walk`, unordered), then asserts the file's contents contain no `"Error"` string.

- On Linux the build is sandboxed, so only the closure is visible → deterministic (passes).
- On Darwin the Nix build is **not** sandboxed, so the test sees the host's full `/nix/store`, whose contents differ per runner/run. The same `mcp-nixos` derivation passed on the PR run for #492 but failed on the post-merge `main` run — same derivation hash, different store contents → the dice landed differently.

`mcp-nixos` is the only package the checks exercised via the `nixos` server, and it was only pulled in by this example.

## What

Remove the `nixos` server entry from `examples/opencode.nix`. The example exists to demonstrate opencode's config format, which is already covered by `filesystem` (with args) and `fetch` (no args). `mcp-nixos` is built and tested in nixpkgs, so this repo does not need to cover it.

## Test

- `nix build .#checks.aarch64-darwin.example-opencode` → succeeds
- `nix fmt -- --ci` → 0 changed