### PR TITLE
chrome-devtools-mcp: init at 1.5.0

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
+          - chrome-devtools-mcp
           - context7-mcp
           - esa-mcp-server
           - freee-mcp
@@ -58,6 +59,8 @@ jobs:
             NIX_UPDATE_FLAGS="--subpackage deps"
           elif [[ "${{ matrix.package }}" == "context7-mcp" ]]; then
             NIX_UPDATE_FLAGS='--version-regex @upstash/context7-mcp@(.*)'
+          elif [[ "${{ matrix.package }}" == "chrome-devtools-mcp" ]]; then
+            NIX_UPDATE_FLAGS='--version-regex chrome-devtools-mcp-v(.*)'
           else
             NIX_UPDATE_FLAGS=""
           fi

--- a/docs/module-options.md
+++ b/docs/module-options.md
@@ -92,6 +92,303 @@ one of “json”, “yaml”, “toml”, “toml-inline”
 
 
 
+## programs\.chrome-devtools\.enable
+
+
+
+Whether to enable chrome-devtools\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+
+
+*Example:*
+
+```nix
+true
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.package
+
+
+
+The chrome-devtools-mcp package to use\.
+
+
+
+*Type:*
+package
+
+
+
+*Default:*
+
+```nix
+pkgs.chrome-devtools-mcp
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.args
+
+
+
+Array of arguments passed to the command\.
+
+
+
+*Type:*
+list of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+[ ]
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.env
+
+
+
+Environment variables for the server\.
+For security reasons, do not hardcode your credentials in the env\.
+All files in /nix/store can be read by anyone with access to the store\.
+Always use envFile instead\.
+
+
+
+*Type:*
+attribute set of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.envFile
+
+
+
+Path to an \.env from which to load additional environment variables\.
+When flavor is set to ‘vscode’, the environment file is passed directly as a parameter instead of wrapping by default\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.executable
+
+
+
+Path to the Chrome or Chromium executable the server launches\.
+
+The server does not ship a browser, and its default channel lookup
+relies on FHS paths that do not exist on NixOS, so a Nix-provided
+browser is passed explicitly\.
+
+
+
+*Type:*
+absolute path
+
+
+
+*Default:*
+
+```nix
+if pkgs.stdenv.hostPlatform.isDarwin then
+  lib.getExe pkgs.google-chrome
+else
+  lib.getExe pkgs.chromium
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.headers
+
+
+
+HTTP headers for authentication\.
+Used with “http” and “sse” transport types\.
+For security reasons, do not hardcode credentials in headers\.
+Use variable expansion syntax (e\.g\., ${VAR}) supported by the client\.
+Set environment variables before launching the client instead\.
+
+
+
+*Type:*
+attribute set of string
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+```nix
+{ Authorization = "Bearer \${API_TOKEN}"; }
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.passwordCommand
+
+
+
+Command to execute to retrieve secrets\. Can be specified in two ways:
+
+ 1. As a string: The command should output in the format “KEY=VALUE” which will be exported as environment variables\.
+    Example: “pass mcp-server”
+
+ 2. As an attribute set: Keys are environment variable names and values are command lists that output the value\.
+    Example: { GITHUB_PERSONAL_ACCESS_TOKEN = \[ “gh” “auth” “token” ]; }
+
+This is useful for integrating with password managers or similar tools\.
+passwordCommand is always handled via the wrapper regardless of flavor\.
+
+
+
+*Type:*
+null or string or attribute set of list of string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+
+
+*Example:*
+
+```nix
+{
+  GITHUB_PERSONAL_ACCESS_TOKEN = [
+    "gh"
+    "auth"
+    "token"
+  ];
+}
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.type
+
+
+
+Server connection type\.
+
+
+
+*Type:*
+null or one of “http”, “sse”, “stdio”
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
+## programs\.chrome-devtools\.url
+
+
+
+URL of the server (for “http” and “sse”)\.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/chrome-devtools\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/chrome-devtools.nix)
+
+
+
 ## programs\.clickup\.enable
 
 
@@ -2511,8 +2808,6 @@ true
 
 ## programs\.git\.package
 
-
-
 The mcp-server-git package to use\.
 
 
@@ -2912,6 +3207,8 @@ attribute set of string
 
 
 ## programs\.github\.passwordCommand
+
+
 
 Command to execute to retrieve secrets\. Can be specified in two ways:
 
@@ -5452,8 +5749,6 @@ true
 
 ## programs\.sequential-thinking\.package
 
-
-
 The mcp-server-sequential-thinking package to use\.
 
 
@@ -5866,6 +6161,8 @@ null
 
 
 ## programs\.serena\.extraPackages
+
+
 
 Extra packages available in the serena wrapper’s PATH\.
 This is useful for including language servers and other tools

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -67,6 +67,7 @@ Add all MCP server packages to your nixpkgs via the provided overlay:
 
 | Package | Description |
 |---------|-------------|
+| `chrome-devtools-mcp` | Chrome DevTools browser debugging |
 | `context7-mcp` | Context7 documentation lookup |
 | `deepl-mcp-server` | DeepL translation |
 | `esa-mcp-server` | esa.io integration |

--- a/modules/servers/chrome-devtools.nix
+++ b/modules/servers/chrome-devtools.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  pkgs,
+  lib,
+  mkServerModule,
+  ...
+}:
+let
+  cfg = config.programs.chrome-devtools;
+in
+{
+  imports = [
+    (mkServerModule {
+      name = "chrome-devtools";
+      packageName = "chrome-devtools-mcp";
+    })
+  ];
+
+  options.programs.chrome-devtools = {
+    executable = lib.mkOption {
+      type = lib.types.path;
+      default =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          lib.getExe pkgs.google-chrome
+        else
+          lib.getExe pkgs.chromium;
+      defaultText = lib.literalExpression ''
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          lib.getExe pkgs.google-chrome
+        else
+          lib.getExe pkgs.chromium
+      '';
+      description = ''
+        Path to the Chrome or Chromium executable the server launches.
+
+        The server does not ship a browser, and its default channel lookup
+        relies on FHS paths that do not exist on NixOS, so a Nix-provided
+        browser is passed explicitly.
+      '';
+    };
+  };
+
+  config.settings.servers = lib.mkIf cfg.enable {
+    chrome-devtools = {
+      args = [
+        "--executable-path"
+        cfg.executable
+      ];
+    };
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -26,6 +26,7 @@ in
   mcp-server-time = pkgs.callPackage ./reference/time.nix { };
 
   # official servers
+  chrome-devtools-mcp = pkgs.callPackage ./official/chrome-devtools { };
   context7-mcp = pkgs.callPackage ./official/context7 { };
   deepl-mcp-server = pkgs.callPackage ./official/deepl { };
   esa-mcp-server = pkgs.callPackage ./official/esa { };

--- a/pkgs/official/chrome-devtools/default.nix
+++ b/pkgs/official/chrome-devtools/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  makeBinaryWrapper,
+  nodejs_24,
+  versionCheckHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "chrome-devtools-mcp";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "ChromeDevTools";
+    repo = "chrome-devtools-mcp";
+    tag = "chrome-devtools-mcp-v${finalAttrs.version}";
+    hash = "sha256-qDji1ZA46H3+jEZ5SL7ga/pyRhJ9SAdBWYH1jKC/TVg=";
+  };
+
+  npmDepsHash = "sha256-t9PwLvjcUaGFBZpW504+V96TbEVukOp3skomtTFs8cA=";
+
+  # Upstream runs its TypeScript build scripts directly with `node`, which
+  # needs a Node with native type stripping.
+  nodejs = nodejs_24;
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  # puppeteer is a build-time dependency that upstream bundles into the
+  # server; its postinstall would otherwise download a Chrome binary the Nix
+  # sandbox cannot fetch. No browser is shipped: point the server at one at
+  # runtime (the module's `executable` option does this via --executable-path).
+  env = {
+    PUPPETEER_SKIP_DOWNLOAD = "true";
+
+    # Rollup needs ~3GB of heap to bundle lighthouse and the DevTools
+    # frontend. V8 derives its default limit from physical memory, which on
+    # small builders (the 7GB macOS CI runners) lands below that and aborts
+    # the bundle step with "JavaScript heap out of memory".
+    NODE_OPTIONS = "--max-old-space-size=4096";
+  };
+
+  # buildNpmPackage installs with `--ignore-scripts`, so the root `prepare`
+  # script does not run automatically. It patches a conflicting global type
+  # declaration in a dependency that otherwise breaks the `tsc` build.
+  preBuild = ''
+    npm run prepare
+  '';
+
+  # `bundle` runs tsc + rollup to produce the self-contained build/ output
+  # with all runtime dependencies vendored into build/src/third_party.
+  npmBuildScript = "bundle";
+
+  # Opt out of upstream's telemetry by default: usage statistics sent to
+  # Google and performance-trace URLs sent to the CrUX API. Both stay
+  # overridable (yargs is last-wins), e.g. `--usage-statistics` re-enables it.
+  postInstall = ''
+    wrapProgram $out/bin/chrome-devtools-mcp \
+      --add-flags "--no-usage-statistics --no-performance-crux" \
+      --set-default CHROME_DEVTOOLS_MCP_NO_UPDATE_CHECKS 1
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "Chrome DevTools MCP server for debugging web pages in a live Chrome browser";
+    homepage = "https://github.com/ChromeDevTools/chrome-devtools-mcp";
+    changelog = "https://github.com/ChromeDevTools/chrome-devtools-mcp/releases/tag/chrome-devtools-mcp-v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ aldoborrero ];
+    mainProgram = "chrome-devtools-mcp";
+  };
+})


### PR DESCRIPTION
## What

Adds [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp) (official Google project) — an MCP server that lets agents drive a live Chrome browser over the Chrome DevTools Protocol (navigate, click/fill, screenshots, console/network inspection, performance traces) — plus its configuration module.

## Package (`pkgs/official/chrome-devtools`)

- `buildNpmPackage` from the GitHub tag `chrome-devtools-mcp-v${version}` (tags are prefixed).
- Upstream's runtime deps (Puppeteer, Lighthouse, the DevTools frontend) are `devDependencies` that the `bundle` script (tsc → rollup) vendors into `build/src/third_party`, so the output is self-contained.
- `PUPPETEER_SKIP_DOWNLOAD=true` — stops puppeteer's postinstall from downloading a Chrome the sandbox can't fetch.
- `preBuild = "npm run prepare"` — `buildNpmPackage` installs with `--ignore-scripts`, so the root `prepare` script (which patches a dependency's conflicting type declaration, otherwise `tsc` fails) is run manually.
- `nodejs_24` — upstream runs its TypeScript build scripts directly with `node`.
- Telemetry (usage statistics to Google, CrUX trace URLs) is disabled by default via a wrapper (`--no-usage-statistics --no-performance-crux`); both remain overridable.

## Module (`modules/servers/chrome-devtools.nix`)

Mirrors the `playwright` module: the server ships no browser and its default channel lookup relies on FHS paths absent on NixOS, so an `executable` option passes a Nix-provided browser via `--executable-path` (defaults to `chromium` on Linux, `google-chrome` on Darwin).

```nix
programs.chrome-devtools.enable = true;
# optional: programs.chrome-devtools.executable = lib.getExe pkgs.ungoogled-chromium;
```

## Testing

- `nix build .#chrome-devtools-mcp` succeeds; `versionCheckHook` reports `1.5.0`.
- `nix build .#checks.x86_64-linux.module-options-doc` passes (`docs/module-options.md` regenerated).
- Module eval (`test-home-manager-module-basic`) passes; `mkConfig` with the module enabled emits `--executable-path <chromium>`.
- End-to-end: the server launched a Nix-provided Chromium headless and drove it through an MCP `new_page` call.

## Note

I'd suggest adding `chrome-devtools-mcp` to the `update-packages.yml` matrix with `--version-regex 'chrome-devtools-mcp-v(.*)'` for the prefixed tags. I left the workflow file out of this PR since my token lacks the `workflow` scope — happy to add it if you'd prefer, or you can drop it into the matrix directly.