### PR TITLE
mcp-gsheets: init at 1.9.0

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -15,6 +15,7 @@ jobs:
           - context7-mcp
           - esa-mcp-server
           - freee-mcp
+          - mcp-gsheets
           - nd-mcp
           - playwright-mcp
           - serena

--- a/docs/module-options.md
+++ b/docs/module-options.md
@@ -3270,6 +3270,271 @@ null
 
 
 
+## programs\.gsheets\.enable
+
+
+
+Whether to enable gsheets\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+
+
+*Example:*
+
+```nix
+true
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/gsheets\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/gsheets.nix)
+
+
+
+## programs\.gsheets\.package
+
+
+
+The mcp-gsheets package to use\.
+
+
+
+*Type:*
+package
+
+
+
+*Default:*
+
+```nix
+pkgs.mcp-gsheets
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/gsheets\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/gsheets.nix)
+
+
+
+## programs\.gsheets\.args
+
+
+
+Array of arguments passed to the command\.
+
+
+
+*Type:*
+list of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+[ ]
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/gsheets\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/gsheets.nix)
+
+
+
+## programs\.gsheets\.env
+
+
+
+Environment variables for the server\.
+For security reasons, do not hardcode your credentials in the env\.
+All files in /nix/store can be read by anyone with access to the store\.
+Always use envFile instead\.
+
+
+
+*Type:*
+attribute set of (boolean or signed integer or string)
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/gsheets\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/gsheets.nix)
+
+
+
+## programs\.gsheets\.envFile
+
+
+
+Path to an \.env from which to load additional environment variables\.
+When flavor is set to ‘vscode’, the environment file is passed directly as a parameter instead of wrapping by default\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/gsheets\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/gsheets.nix)
+
+
+
+## programs\.gsheets\.headers
+
+
+
+HTTP headers for authentication\.
+Used with “http” and “sse” transport types\.
+For security reasons, do not hardcode credentials in headers\.
+Use variable expansion syntax (e\.g\., ${VAR}) supported by the client\.
+Set environment variables before launching the client instead\.
+
+
+
+*Type:*
+attribute set of string
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+```nix
+{ Authorization = "Bearer \${API_TOKEN}"; }
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/gsheets\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/gsheets.nix)
+
+
+
+## programs\.gsheets\.passwordCommand
+
+
+
+Command to execute to retrieve secrets\. Can be specified in two ways:
+
+ 1. As a string: The command should output in the format “KEY=VALUE” which will be exported as environment variables\.
+    Example: “pass mcp-server”
+
+ 2. As an attribute set: Keys are environment variable names and values are command lists that output the value\.
+    Example: { GITHUB_PERSONAL_ACCESS_TOKEN = \[ “gh” “auth” “token” ]; }
+
+This is useful for integrating with password managers or similar tools\.
+passwordCommand is always handled via the wrapper regardless of flavor\.
+
+
+
+*Type:*
+null or string or attribute set of list of string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+
+
+*Example:*
+
+```nix
+{
+  GITHUB_PERSONAL_ACCESS_TOKEN = [
+    "gh"
+    "auth"
+    "token"
+  ];
+}
+
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/gsheets\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/gsheets.nix)
+
+
+
+## programs\.gsheets\.type
+
+
+
+Server connection type\.
+
+
+
+*Type:*
+null or one of “http”, “sse”, “stdio”
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/gsheets\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/gsheets.nix)
+
+
+
+## programs\.gsheets\.url
+
+
+
+URL of the server (for “http” and “sse”)\.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [\<mcp-servers-nix/modules/servers/gsheets\.nix>](https://github.com/natsukium/mcp-servers-nix/blob/main/modules/servers/gsheets.nix)
+
+
+
 ## programs\.home-assistant\.enable
 
 
@@ -5602,8 +5867,6 @@ null
 
 ## programs\.serena\.extraPackages
 
-
-
 Extra packages available in the serena wrapper’s PATH\.
 This is useful for including language servers and other tools
 that serena needs to access\.
@@ -5918,6 +6181,8 @@ pkgs.tavily-mcp
 
 
 ## programs\.tavily\.args
+
+
 
 Array of arguments passed to the command\.
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -76,3 +76,9 @@ Add all MCP server packages to your nixpkgs via the provided overlay:
 | `playwright-mcp` | Playwright browser automation |
 | `serena` | Serena code intelligence |
 | `tavily-mcp` | Tavily search |
+
+### Community Servers
+
+| Package | Description |
+|---------|-------------|
+| `mcp-gsheets` | Google Sheets read/write |

--- a/modules/servers/gsheets.nix
+++ b/modules/servers/gsheets.nix
@@ -1,0 +1,9 @@
+{ mkServerModule, ... }:
+{
+  imports = [
+    (mkServerModule {
+      name = "gsheets";
+      packageName = "mcp-gsheets";
+    })
+  ];
+}

--- a/pkgs/community/mcp-gsheets/default.nix
+++ b/pkgs/community/mcp-gsheets/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "mcp-gsheets";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "freema";
+    repo = "mcp-gsheets";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fDfsMZ2e7yr5baXsoz4MDs8jmErH60Q/w2Ixo1Eh4+o=";
+  };
+
+  npmDepsHash = "sha256-aq6E9nk6597mtXahku9cub/uU9hsSj2GjdlXeoZTAv4=";
+
+  # `npm run build` (tsup) bundles src into dist/, keeping googleapis and the
+  # google-auth stack external, so the pruned production node_modules is kept
+  # in the output for them to resolve at runtime.
+
+  meta = {
+    description = "MCP server for reading and writing Google Sheets via the Google Sheets API";
+    homepage = "https://github.com/freema/mcp-gsheets";
+    changelog = "https://github.com/freema/mcp-gsheets/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aldoborrero ];
+    mainProgram = "mcp-gsheets";
+  };
+})

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -41,5 +41,6 @@ in
   slite-mcp-server = warnRemoved "slite-mcp-server has been removed since upstream stopped distribution in favor of the hosted MCP server at https://api.slite.com/mcp";
 
   # community servers
+  mcp-gsheets = pkgs.callPackage ./community/mcp-gsheets { };
   clickup-mcp-server = warnRemoved "clickup-mcp-server has been removed since upstream stopped distribution and switched to shareware";
 }


### PR DESCRIPTION
## What

Adds [`mcp-gsheets`](https://github.com/freema/mcp-gsheets) — a community MCP server for reading and writing Google Sheets via the Google Sheets API — plus a configuration module. It exposes ~44 `sheets_*` tools (get/update/batch values, metadata, formatting, sheet management, and native Tables: add/update/delete/get).

## Package (`pkgs/community/mcp-gsheets`)

- `buildNpmPackage` from the GitHub tag `v${version}`.
- `npm run build` (tsup) bundles `src/` into `dist/` while keeping `googleapis` and the google-auth stack external, so the pruned production `node_modules` is kept in the output for them to resolve at runtime.
- No `versionCheckHook`: the server has no `--version` flag (invoking the bin starts the stdio server).

This is the first active package under `pkgs/community/`.

## Module (`modules/servers/gsheets.nix`)

A basic `mkServerModule` (`programs.gsheets`, package `mcp-gsheets`). Authentication uses a Google service account passed via environment variables (`GOOGLE_PROJECT_ID` plus `GOOGLE_APPLICATION_CREDENTIALS` or `GOOGLE_SERVICE_ACCOUNT_KEY`), which flow through the framework's standard `env` / `envFile` / `passwordCommand` options — no custom options needed.

```nix
programs.gsheets = {
  enable = true;
  env.GOOGLE_PROJECT_ID = "my-project";
  envFile = "/run/secrets/gsheets";  # GOOGLE_APPLICATION_CREDENTIALS=...
};
```

## Testing

- `nix build .#mcp-gsheets` succeeds; `googleapis` resolves in the runtime closure.
- `nix build .#checks.x86_64-linux.module-options-doc` passes (`docs/module-options.md` regenerated); `docs/packages.md` updated with a Community Servers section.
- Module eval (`test-home-manager-module-basic`) passes; `mkConfig` with `programs.gsheets.enable` emits the `mcp-gsheets` command.
- End-to-end MCP handshake: the server initializes and lists 44 `sheets_*` tools over stdio, including the native Tables tools (`sheets_add_table`, `sheets_update_table`, `sheets_delete_table`, `sheets_get_tables`).

## Note

For CI auto-updates you may want to add `mcp-gsheets` to the `update-packages.yml` matrix (`nix-update` with `--version-regex 'v(.*)'` handles the `v`-prefixed tags). I left the workflow file out since my token lacks the `workflow` scope — happy to add it if you'd like.