### PR TITLE
reference-servers: 2026.1.26 -> 2026.7.10

### DIFF
--- a/pkgs/reference/generic-ts.nix
+++ b/pkgs/reference/generic-ts.nix
@@ -17,7 +17,7 @@ buildNpmPackage {
 
   nodejs = nodejs_22;
 
-  npmDepsHash = "sha256-jmz4JdpeHH07vJQFntBwrENbJaIcOuZMb7+qf497VOE=";
+  npmDepsHash = "sha256-KhlTXcS+VDSPGnEus9fA0xhIxfTGwX1Cr5hbxFvdc2k=";
 
   npmWorkspace = "src/${workspace}";
 

--- a/pkgs/reference/source.nix
+++ b/pkgs/reference/source.nix
@@ -1,10 +1,10 @@
 { fetchFromGitHub }:
 rec {
-  version = "2026.1.26";
+  version = "2026.7.10";
   src = fetchFromGitHub {
     owner = "modelcontextprotocol";
     repo = "servers";
     tag = version;
-    hash = "sha256-uULXUEHFZpYm/fmF6PkOFCxS+B+0q3dMveLG+3JHrhk=";
+    hash = "sha256-ORihWA8Xx7WAPo2+vRPpYNF9CGfc1sjmW+NfUKBGzxs=";
   };
 }


### PR DESCRIPTION
Diff: https://github.com/modelcontextprotocol/servers/compare/2026.1.26...2026.7.10
Changelog: https://github.com/modelcontextprotocol/servers/releases/tag/2026.7.10