### PR TITLE
notion-mcp-server: 1.9.0 -> 2.5.0

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -17,6 +17,7 @@ jobs:
           - freee-mcp
           - mcp-gsheets
           - nd-mcp
+          - notion-mcp-server
           - playwright-mcp
           - serena
     steps:

--- a/pkgs/official/notion/default.nix
+++ b/pkgs/official/notion/default.nix
@@ -4,18 +4,18 @@
   buildNpmPackage,
 }:
 
-buildNpmPackage {
+buildNpmPackage (finalAttrs: {
   pname = "notion-mcp-server";
-  version = "1.9.0";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "makenotion";
     repo = "notion-mcp-server";
-    rev = "ffc1b18807df0cd72717f6ba55e7866af2d91ccd";
-    hash = "sha256-e1OHix3fJ2LKgdOML6LMQOb6573VMr0g/1AA/3Izu74=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fbr1i66YmFctaZ3xu/zgfOiRm61Jh1Sh2l2+zg7tcNQ=";
   };
 
-  npmDepsHash = "sha256-d+C5twhyH0ZQFI0/n7R3jPU864yFgD9Cni2Qu3dahjc=";
+  npmDepsHash = "sha256-oPJVGWzQhr+NoYMueeECY+toxCp/GfaJUGKIqglcj+A=";
 
   meta = {
     description = "Official Notion MCP Server";
@@ -24,4 +24,4 @@ buildNpmPackage {
     maintainers = with lib.maintainers; [ natsukium ];
     mainProgram = "notion-mcp-server";
   };
-}
+})


### PR DESCRIPTION
Pin the source by tag rather than by bare commit: upstream started
publishing v-prefixed release tags with 2.0.0, which lets nix-update
discover new versions and makes the package eligible for automatic
updates.

Diff: makenotion/notion-mcp-server@ffc1b18...v2.5.0
Changelog: https://github.com/makenotion/notion-mcp-server/releases/tag/v2.5.0